### PR TITLE
Make Websocket server address configurable

### DIFF
--- a/charge-backend/charge_server.py
+++ b/charge-backend/charge_server.py
@@ -1,6 +1,6 @@
 from functools import partial
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
-from fastapi.responses import FileResponse
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 import asyncio
@@ -128,7 +128,16 @@ if os.path.exists(ASSETS_PATH):
 
     @app.get("/")
     async def root():
-        return FileResponse(os.path.join(DIST_PATH, "index.html"))
+        with open(os.path.join(DIST_PATH, "index.html"), 'r') as fp:
+            html = fp.read()
+
+        html = html.replace('<!-- APP CONFIG -->', f'''
+           <script>
+           window.APP_CONFIG = {{
+               WS_SERVER: '{os.getenv("WS_SERVER", "ws://localhost:8001/ws")}'
+           }};
+           </script>''')
+        return HTMLResponse(html)
 
 
 def make_client(client, task, server_urls, websocket):

--- a/flask-app/index.html
+++ b/flask-app/index.html
@@ -10,6 +10,7 @@
     />
     <link href="/src/style.css" rel="stylesheet">
     <title>FLASK Copilot</title>
+    <!-- APP CONFIG -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -4,11 +4,12 @@ import { Loader2, FlaskConical, TestTubeDiagonal, Network, Play, RotateCcw, Move
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { RDKitModule } from '@rdkit/rdkit';
 
+import { WS_SERVER } from './config';
+
 const MOLECULE_WIDTH = 250;
 const BOX_WIDTH = 10 + MOLECULE_WIDTH + 10;
 const BOX_GAP = 160;
 const BOX_HEIGHT = 100;
-const WS_SERVER = "ws://localhost:8001/ws";
 
 const NODE_STYLES = {
   "normal": 'from-purple-50/80 to-pink-300/80 border-purple-400/50 hover:border-purple-300',

--- a/flask-app/src/config.ts
+++ b/flask-app/src/config.ts
@@ -1,0 +1,28 @@
+export interface AppConfig {
+  // WebSocket
+  WS_SERVER: string;
+};
+
+declare global {
+  interface Window {
+    APP_CONFIG?: Partial<AppConfig>;
+  }
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+  WS_SERVER: 'ws://localhost:8001/ws'
+};
+
+let config: AppConfig | null = null;
+
+export const getConfig = (): AppConfig => {
+    if (!config) {
+        config = {
+        ...DEFAULT_CONFIG,
+        ...(window.APP_CONFIG || {})
+        };
+    }
+    return config;
+};
+
+export const WS_SERVER = getConfig().WS_SERVER;

--- a/mock_server.py
+++ b/mock_server.py
@@ -16,7 +16,7 @@ Supported messages from frontend to server:
 """
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
-from fastapi.responses import StreamingResponse, FileResponse
+from fastapi.responses import StreamingResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from dataclasses import dataclass, asdict
@@ -51,7 +51,16 @@ if os.path.exists(ASSETS_PATH):
 
     @app.get("/")
     async def root():
-        return FileResponse(os.path.join(DIST_PATH, "index.html"))
+        with open(os.path.join(DIST_PATH, "index.html"), 'r') as fp:
+            html = fp.read()
+
+        html = html.replace('<!-- APP CONFIG -->', f'''
+           <script>
+           window.APP_CONFIG = {{
+               WS_SERVER: '{os.getenv("WS_SERVER", "ws://localhost:8001/ws")}'
+           }};
+           </script>''')
+        return HTMLResponse(html)
 
 CACTUS = "https://cactus.nci.nih.gov/chemical/structure/{0}/{1}"
 


### PR DESCRIPTION
This allows the websocket server address to be configured by default in the app and using an environment variable (if served by a production system). If no address is given, uses `ws://localhost:8001/ws`