### PR TITLE
Reconfigurable server in development mode

### DIFF
--- a/flask-app/vite.config.ts
+++ b/flask-app/vite.config.ts
@@ -36,4 +36,7 @@ export default defineConfig({
     tailwindcss(),
     copyRDKitFiles()
   ],
+  define: {
+    'window.APP_CONFIG.WS_SERVER': JSON.stringify(process.env.WS_SERVER || 'ws://localhost:8001/ws')
+  }
 });


### PR DESCRIPTION
This enables reconfiguring the websocket server in development mode with `WS_SERVER=ws://myaddress npm start dev`