### PR TITLE
Bugfix newer MCP libraries

### DIFF
--- a/charge_backend/lmo_tool_server.py
+++ b/charge_backend/lmo_tool_server.py
@@ -12,7 +12,7 @@ from loguru import logger
 import uvicorn
 
 from charge.servers.server_utils import update_mcp_network, get_hostname
-from tool_registration import register_tool_server
+from tool_registration import register_tool_server, get_asgi_app
 
 
 @click.command()
@@ -96,9 +96,9 @@ def main(
 
     mcp = LMO_MCP.mcp
 
-    asgi_app = mcp.get_asgi_app()
+    asgi_app = get_asgi_app(mcp)
     if asgi_app:
-        uvicorn.run(asgi_app, host=host or "0.0.0.0", port=port)
+        uvicorn.run(asgi_app, host=host or "0.0.0.0", port=port, factory=True)
     else:
         logger.error("Could not access FastMCP ASGI app")
 

--- a/charge_backend/molecular_property_surrogates_tool_servers.py
+++ b/charge_backend/molecular_property_surrogates_tool_servers.py
@@ -12,7 +12,7 @@ from loguru import logger
 import uvicorn
 
 from charge.servers.server_utils import update_mcp_network, get_hostname
-from tool_registration import register_tool_server
+from tool_registration import register_tool_server, get_asgi_app
 from mcp.server.fastmcp import FastMCP
 
 from charge.servers.molecular_property_utils import calculate_property_hf
@@ -55,10 +55,12 @@ def main(
         "Computationally expensive surrogate models for molecular properties MCP Server",
         sse_path=f"/mol_prop_tools/sse",
         message_path=f"/mol_prop_tools/messages/",
+        host=host,
+        port=port,
     )
     mcp.tool()(calculate_property_hf)
 
-    asgi_app = mcp.get_asgi_app()
+    asgi_app = get_asgi_app(mcp)
     if asgi_app:
         uvicorn.run(asgi_app, host=host or "0.0.0.0", port=port)
     else:

--- a/charge_backend/retro_tool_server.py
+++ b/charge_backend/retro_tool_server.py
@@ -13,7 +13,7 @@ from charge.servers.AiZynthTools import is_molecule_synthesizable, RetroPlanner
 
 import charge.servers.retrosynthesis_reaction_server as RETRO_MCP
 from charge.servers.server_utils import update_mcp_network, get_hostname
-from tool_registration import register_tool_server
+from tool_registration import register_tool_server, get_asgi_app
 
 
 @click.command()
@@ -48,7 +48,7 @@ def main(port, host, name, copilot_port, copilot_host, config):
     RetroPlanner.initialize(configfile=config)
     mcp.tool()(is_molecule_synthesizable)
 
-    asgi_app = mcp.get_asgi_app()
+    asgi_app = get_asgi_app(mcp)
     if asgi_app:
         uvicorn.run(asgi_app, host=host or "0.0.0.0", port=port)
     else:

--- a/charge_backend/tool_registration.py
+++ b/charge_backend/tool_registration.py
@@ -17,6 +17,8 @@ import time
 import os
 import re
 import asyncio
+from mcp.server.fastmcp import FastMCP
+
 from charge.utils.mcp_workbench_utils import (
     _setup_mcp_workbenches,
     _close_mcp_workbenches,
@@ -531,3 +533,12 @@ def list_server_urls() -> list[str]:
 async def list_server_tools(urls: list[str]):
     workbenches = [McpWorkbench(SseServerParams(url=server)) for server in urls]
     return await _list_wb_tools(workbenches)
+
+
+def get_asgi_app(mcp: FastMCP):
+    asgi_app = (
+        getattr(mcp, "sse_app", None)
+        or getattr(mcp, "asgi_app", None)
+        or getattr(mcp, "_app", None)
+    )
+    return asgi_app


### PR DESCRIPTION
Updated how the ports and host IP address is set for the MCP servers.
Newer versions of MCP don't allow the host and port to be changed after initialization.  Switched to using uvicorn.run instead of mcp.run to avoid this issue.