### PR TITLE
Integrate ChARGe RSA algorithm

### DIFF
--- a/charge_backend/backend_helper_funcs.py
+++ b/charge_backend/backend_helper_funcs.py
@@ -10,7 +10,8 @@ from dataclasses import asdict
 from flask_tools.chemistry import smiles_utils
 from flask_tools.lmo.molecular_property_utils import get_density
 from lc_conductor import CallbackLogger, RunSettings
-from charge_backend.moleculedb.molecule_naming import MolNameFormat
+from charge_backend.moleculedb.molecule_naming import MolNameFormat, smiles_to_html
+from charge_backend.moleculedb.purchasable import is_purchasable
 
 
 @dataclass
@@ -108,6 +109,12 @@ class ModelMessage:
 @dataclass
 class FlaskRunSettings(RunSettings):
     molecule_name_format: MolNameFormat = Field(alias="moleculeName", default="brand")
+    # RSA settings
+    use_rsa: bool = Field(alias="useRsa", default=False)
+    rsa_n: int = Field(alias="rsaN", default=8)
+    rsa_k: int = Field(alias="rsaK", default=4)
+    rsa_t: int = Field(alias="rsaT", default=3)
+    rsa_mode: str = Field(alias="rsaMode", default="standalone")
 
 
 @dataclass(frozen=True)
@@ -122,6 +129,33 @@ class RdkitjsMolPayload:
     smiles: str
     highlight_atom_idxs: list[int]
     highlight_atom_mapnums: list[int]
+
+
+def build_root_node(smiles: str, run_settings: "FlaskRunSettings") -> "Node":
+    """Build the level-0 root Node for a retrosynthesis run.
+
+    Shared by ai_based_retrosynthesis and template_based_retrosynthesis to
+    avoid duplicating the Node construction in two places.
+    """
+    mol_sources = is_purchasable(smiles)
+    purchasable_str = (
+        f"Yes (via {', '.join(mol_sources)})" if mol_sources else "No"
+    )
+    return Node(
+        id="node_0",
+        smiles=smiles,
+        label=smiles_to_html(smiles, run_settings.molecule_name_format),
+        hoverInfo=f"# Root molecule\n**SMILES:** {smiles}\n\n**Purchasable**? {purchasable_str}",
+        level=0,
+        parentId=None,
+        cost=None,
+        bandgap=None,
+        yield_=None,
+        purchasable=bool(mol_sources),
+        highlight="yellow",
+        x=100,
+        y=100,
+    )
 
 
 def get_price(smiles: str) -> float:

--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 from fastapi import WebSocket
 import asyncio
-import os
 from lc_conductor import ActionManager, TaskManager, CallbackLogger
 from lc_conductor import (
     BuiltinToolDefinition,
@@ -323,14 +322,37 @@ class FlaskActionManager(ActionManager):
 
     async def _handle_retrosynthesis(self, data: dict) -> None:
         """Handle retrosynthesis problem type."""
-        run_func = partial(
-            template_based_retrosynthesis,
-            data["smiles"],
-            self.args.config_file,
-            self.get_retro_synth_context(),
-            self.task_manager.websocket,
-            self.run_settings,
-        )
+        # aiOnly flag (top-level on the websocket message) controls AI vs template approach.
+        # template_based_retrosynthesis surfaces a "no routes found" message when the
+        # AZF config is missing, so no pre-check is needed here.
+        ai_only = data.get("aiOnly", True)
+
+        if ai_only:
+            # ai_based_retrosynthesis creates the root node itself when given root_smiles.
+            run_func = partial(
+                ai_based_retrosynthesis,
+                "node_0",
+                self.get_retro_synth_context(),
+                data.get("query", None),
+                None,  # Unconstrained
+                self.task_manager.websocket,
+                self.experiment,
+                self.args.config_file,
+                self.run_settings,
+                self.selected_tool_runtime(),
+                self.log_progress,
+                root_smiles=data["smiles"],
+            )
+        else:
+            # Use template-based retrosynthesis
+            run_func = partial(
+                template_based_retrosynthesis,
+                data["smiles"],
+                self.args.config_file,
+                self.get_retro_synth_context(),
+                self.task_manager.websocket,
+                self.run_settings,
+            )
 
         await self.task_manager.run_task(run_func())
 

--- a/charge_backend/retrosynthesis/ai.py
+++ b/charge_backend/retrosynthesis/ai.py
@@ -12,6 +12,7 @@ from charge_backend.backend_helper_funcs import (
     ReactionAlternative,
     PathwayStep,
     FlaskRunSettings,
+    build_root_node,
 )
 from charge_backend.prompt_debugger import debug_prompt
 from charge_backend.retrosynthesis.context import RetrosynthesisContext
@@ -72,9 +73,25 @@ async def ai_based_retrosynthesis(
     tool_runtime: ToolRuntime,
     log_progress: ReasoningCallbackType,
     attachments: Optional[list[dict[str, object]]] = None,
+    root_smiles: Optional[str] = None,
 ):
-    """Performs template-free retrosynthesis using the AI orchestrator."""
+    """Performs template-free retrosynthesis using the AI orchestrator.
+
+    If ``root_smiles`` is provided and ``node_id`` is not yet in the context,
+    a fresh root node is created from that SMILES (used by the initial compute
+    action). Callers that already have a populated context (e.g.
+    ``db_then_ai_retrosynthesis``) leave ``root_smiles`` as ``None``.
+    """
     clogger = CallbackLogger(websocket, source="ai_based_retrosynthesis")
+
+    if root_smiles is not None:
+        # Caller wants a fresh compute starting from root_smiles. Reset and rebuild
+        # unconditionally so a second compute in the same session does not inherit
+        # stale nodes from the previous run.
+        context.reset()
+        root = build_root_node(root_smiles, run_settings)
+        await context.add_node(root, websocket=websocket)
+
     current_node = context.node_ids.get(node_id)
     if current_node is None:
         await clogger.error(f"Node ID {node_id} not found")
@@ -134,13 +151,45 @@ async def ai_based_retrosynthesis(
         f"Finding synthesis routes for {current_node.smiles} using available tools: {tool_runtime.tool_summary()}."
     )
 
-    # Run task
+    # Run task (with optional RSA mode)
     await highlight_node(current_node, websocket, True)
     if run_settings.prompt_debugging:
         await debug_prompt(runner, websocket)
-    output = await runner.run(log_progress)
-    if isinstance(callback_handler, CallbackHandler):
-        await callback_handler.drain()
+
+    # Check if RSA mode is enabled
+    if run_settings.use_rsa:
+        try:
+            from charge_backend.retrosynthesis.ai_rsa import run_rsa_retrosynthesis
+
+            output, _ = await run_rsa_retrosynthesis(
+                current_node=current_node,
+                runner=runner,
+                callback_handler=callback_handler,
+                run_settings=run_settings,
+                tool_runtime=tool_runtime,
+                user_prompt=user_prompt,
+                clogger=clogger,
+                experiment=experiment,
+                websocket=websocket,
+                node_id=node_id,
+                log_progress=log_progress,
+            )
+        except Exception as e:
+            # Fallback to standard mode if RSA fails
+            await clogger.error(
+                f"RSA mode failed: {str(e)}, falling back to standard retrosynthesis"
+            )
+            # Reset task to original
+            runner.task = retro_task
+            output = await runner.run(log_progress)
+            if isinstance(callback_handler, CallbackHandler):
+                await callback_handler.drain()
+    else:
+        # Standard mode (no RSA)
+        output = await runner.run(log_progress)
+        if isinstance(callback_handler, CallbackHandler):
+            await callback_handler.drain()
+
     experiment.add_to_context(runner, retro_task, output)
 
     if os.getenv("CHARGE_DISABLE_OUTPUT_VALIDATION", "0") == "1":
@@ -150,6 +199,14 @@ async def ai_based_retrosynthesis(
         )
 
     result = ReactionOutputSchema.model_validate_json(output)
+
+    if not result.reactants_smiles_list:
+        await clogger.warning(
+            f"Model returned no reactants for {current_node.smiles}. "
+            "This often indicates a refusal or a malformed output. Try a "
+            "different target molecule, enable RSA mode, or use RSA + RAG "
+            "for a higher success rate."
+        )
 
     await highlight_node(current_node, websocket, False)
 
@@ -244,6 +301,9 @@ async def ai_based_retrosynthesis(
         await context.add_node(node, websocket)
         await asyncio.sleep(0)
 
+    # Template-based expansion of reactants (optional).
+    # run_retro_planner returns (None, []) when the AZF config is missing or no
+    # routes are found, so no separate config-existence check is needed here.
     for node, purch in zip(new_nodes, purchasable):
         if purch:  # Skip purchasable nodes unless explicitly asked for
             continue
@@ -252,23 +312,32 @@ async def ai_based_retrosynthesis(
         await highlight_node(node, websocket, True)
 
         # Find paths for the leaf nodes
-        reaction, routes = await run_retro_planner(
-            config_file, node.smiles, clogger, run_settings
-        )
-        if reaction is None:
-            await clogger.warning(f"No routes found for {node.smiles}. Skipping...")
-            continue
-        node.reaction = reaction
+        try:
+            reaction, routes = await run_retro_planner(
+                config_file, node.smiles, clogger, run_settings
+            )
+            if reaction is None:
+                await clogger.warning(
+                    f"No routes found for {node.smiles}. Skipping..."
+                )
+                await highlight_node(node, websocket, False)
+                continue
+            node.reaction = reaction
 
-        # Use child nodes and edges of the first route
-        await generate_nodes_for_molecular_graph(
-            routes[0].nodes,
-            context,
-            websocket,
-            start_level=level,
-            include_root_node=False,
-            root_node_id=node.id,
-        )
+            # Use child nodes and edges of the first route
+            await generate_nodes_for_molecular_graph(
+                routes[0].nodes,
+                context,
+                websocket,
+                start_level=level,
+                include_root_node=False,
+                root_node_id=node.id,
+            )
+        except Exception as e:
+            await clogger.warning(
+                f"Template-based expansion failed for {node.smiles}: {str(e)}. Continuing..."
+            )
+            await highlight_node(node, websocket, False)
 
         # Attach mapped reaction for immediate reactants -> product.
         # This is needed so hover-highlighting works for the first template step

--- a/charge_backend/retrosynthesis/ai_rsa.py
+++ b/charge_backend/retrosynthesis/ai_rsa.py
@@ -1,0 +1,291 @@
+"""RSA-based retrosynthesis driver.
+
+Holds the chemistry-specific orchestration that sits on top of ChARGe's
+generic RSA loop: loads the retrosynthesis prompt set (standalone or RAG),
+optionally queries the reaction database for RAG context, supplies the
+candidate formatter and proposal validator, and dispatches the loop.
+
+The generic N-K-T RSA algorithm itself lives in ``charge.algorithms`` as
+``RSATask`` and is domain-agnostic; this module plugs the retrosynthesis
+schema, prompts, and validator into it via ``RetroRSATask`` subclass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from fastapi import WebSocket
+
+from lc_conductor.callback_logger import CallbackLogger
+from lc_conductor import ToolRuntime
+
+from charge.algorithms import RSATask
+from charge.experiments.experiment import Experiment
+from charge.clients.agent_factory import ReasoningCallbackType
+
+from charge_backend.backend_helper_funcs import CallbackHandler, FlaskRunSettings, Node
+from charge_backend.retrosynthesis.retrosynthesis_task import (
+    TemplateFreeReactionOutputSchema as ReactionOutputSchema,
+)
+
+
+class RetroRSATask(RSATask):
+    """RSATask specialized for template-free retrosynthesis.
+
+    Uses the chemistry output schema by default and overrides the candidate
+    formatter / validator to emit and check SMILES-based proposals.
+    """
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("structured_output_schema", ReactionOutputSchema)
+        super().__init__(**kwargs)
+
+    def format_candidates(self, subset):
+        """Format retrosynthesis proposals for the aggregation prompt."""
+        text = ""
+        for idx, prop in enumerate(subset, 1):
+            r = prop["result"]
+            text += f"\n---- Candidate {idx} ----\n"
+            text += f"Reasoning: {r.reasoning_summary}\n"
+            text += f"Reactants: {', '.join(r.reactants_smiles_list)}\n"
+            text += f"Products: {', '.join(r.products_smiles_list)}\n"
+        return text
+
+    def validate_proposal(self, result):
+        """A proposal is valid only if it has at least one reactant."""
+        return (
+            hasattr(result, "reactants_smiles_list")
+            and len(result.reactants_smiles_list) > 0
+        )
+
+
+async def run_rsa_retrosynthesis(
+    current_node: Node,
+    runner,
+    callback_handler,
+    run_settings: FlaskRunSettings,
+    tool_runtime: ToolRuntime,
+    user_prompt: str,
+    clogger: CallbackLogger,
+    experiment: Experiment,
+    websocket: WebSocket,
+    node_id: str,
+    log_progress: ReasoningCallbackType,
+) -> tuple[str, ReactionOutputSchema]:
+    """Run RSA-based retrosynthesis. Raises on failure so the caller can
+    fall back to standard retrosynthesis (see ai.py)."""
+
+    rsa_n = run_settings.rsa_n if hasattr(run_settings, "rsa_n") else 8
+    rsa_k = run_settings.rsa_k if hasattr(run_settings, "rsa_k") else 4
+    rsa_t = run_settings.rsa_t if hasattr(run_settings, "rsa_t") else 3
+    rsa_mode = (
+        run_settings.rsa_mode
+        if hasattr(run_settings, "rsa_mode")
+        else "standalone"
+    )
+
+    await clogger.info(
+        f"Running RSA mode: {rsa_mode} with N={rsa_n}, K={rsa_k}, T={rsa_t}"
+    )
+
+    # Load chemistry-specific prompts for retrosynthesis (3-part structure)
+    prompts_dir = Path(__file__).parent / "prompts"
+    system_prompt_file = prompts_dir / f"rsa_{rsa_mode}_system.txt"
+    proposal_file = prompts_dir / f"rsa_{rsa_mode}_proposal.txt"
+    aggregation_file = prompts_dir / f"rsa_{rsa_mode}_aggregation.txt"
+
+    system_prompt = (
+        system_prompt_file.read_text() if system_prompt_file.exists() else None
+    )
+    proposal_prompt = (
+        proposal_file.read_text() if proposal_file.exists() else None
+    )
+    aggregation_prompt = (
+        aggregation_file.read_text() if aggregation_file.exists() else None
+    )
+
+    await clogger.info(f"Loading prompts for mode={rsa_mode}")
+    await clogger.info(
+        f"  System prompt: {system_prompt_file.exists()=}, length={len(system_prompt) if system_prompt else 0}"
+    )
+    await clogger.info(
+        f"  Proposal prompt: {proposal_file.exists()=}, length={len(proposal_prompt) if proposal_prompt else 0}"
+    )
+    await clogger.info(
+        f"  Aggregation prompt: {aggregation_file.exists()=}, length={len(aggregation_prompt) if aggregation_prompt else 0}"
+    )
+
+    # For RAG mode: Query database once and inject into prompts
+    # For standalone mode: Remove database query tool
+    user_prompt_with_rag = user_prompt
+    available_tools = tool_runtime.mcp_server_urls
+    builtin_tools_filtered = tool_runtime.direct_tools
+    db_results_to_save = (
+        None  # Store DB results to save later after log_dir is created
+    )
+
+    if rsa_mode == "rag":
+        await clogger.info("RAG mode: Querying reaction database once...")
+        try:
+            from charge_backend.retrosynthesis.database import query_reaction_database
+
+            db_results = query_reaction_database(current_node.smiles, top_k=10)
+
+            if db_results and not any("error" in r for r in db_results):
+                await clogger.info(
+                    f"Found {len(db_results)} similar reactions in database"
+                )
+
+                summary_lines = [
+                    f"**Database Query Results ({len(db_results)} reactions found):**"
+                ]
+                for idx, reaction in enumerate(db_results[:5], 1):
+                    name = reaction.get("name", f"Reaction {idx}")
+                    summary_lines.append(f"  {idx}. {name}")
+                    if "components" in reaction and reaction["components"]:
+                        reactants = [
+                            c.get("name", c.get("smiles", "?"))
+                            for c in reaction["components"]
+                            if c.get("role") in ["Reactant", "Reagent"]
+                        ]
+                        products = [
+                            c.get("name", c.get("smiles", "?"))
+                            for c in reaction["components"]
+                            if c.get("role") == "Product"
+                        ]
+                        if reactants:
+                            summary_lines.append(
+                                f"     Reactants: {', '.join(reactants[:3])}"
+                            )
+                        if products:
+                            summary_lines.append(
+                                f"     Products: {', '.join(products[:2])}"
+                            )
+                if len(db_results) > 5:
+                    summary_lines.append(
+                        f"  ... and {len(db_results) - 5} more reactions"
+                    )
+                summary_lines.append(
+                    "These reactions will be injected into all proposal prompts."
+                )
+                await clogger.info("\n".join(summary_lines))
+
+                rag_context = "\n\n--- REACTION DATABASE RESULTS ---\n"
+                rag_context += f"These are similar reactions retrieved by comparing structural similarity to the target product ({current_node.smiles}):\n\n"
+
+                for idx, reaction in enumerate(db_results[:10], 1):
+                    rag_context += f"Reaction {idx}:\n"
+                    if "reactants" in reaction:
+                        rag_context += (
+                            f"  Reactants: {reaction.get('reactants', 'N/A')}\n"
+                        )
+                    if "products" in reaction:
+                        rag_context += (
+                            f"  Products: {reaction.get('products', 'N/A')}\n"
+                        )
+                    if "text" in reaction and reaction.get("text"):
+                        rag_context += f"  Description: {reaction['text']}\n"
+                    rag_context += "\n"
+
+                rag_context += "Use these reactions as supporting evidence for your retrosynthesis proposal.\n"
+                rag_context += "--- END DATABASE RESULTS ---\n"
+
+                user_prompt_with_rag = user_prompt + rag_context
+                db_results_to_save = db_results
+            else:
+                await clogger.info("No reactions found in database")
+                user_prompt_with_rag = (
+                    user_prompt
+                    + "\n\nNo similar reactions found in the database for this target molecule.\n"
+                )
+        except Exception as e:
+            await clogger.warning(f"Database query failed: {str(e)}")
+            user_prompt_with_rag = (
+                user_prompt
+                + "\n\nDatabase query failed. Proceed using chemistry knowledge only.\n"
+            )
+
+        # Filter out query_reaction_database from builtin tools (already queried once)
+        builtin_tools_filtered = [
+            tool
+            for tool in builtin_tools_filtered
+            if getattr(tool, "__name__", "") != "query_reaction_database"
+        ]
+        await clogger.info(
+            "RAG mode: Removed query_reaction_database from tools (already queried)"
+        )
+
+    elif rsa_mode == "standalone":
+        # Standalone mode: Remove database query tool entirely (no retrieval)
+        builtin_tools_filtered = [
+            tool
+            for tool in builtin_tools_filtered
+            if getattr(tool, "__name__", "") != "query_reaction_database"
+        ]
+        await clogger.info(
+            "Standalone mode: Removed query_reaction_database from tools (no retrieval)"
+        )
+
+    # Build the retrosynthesis-specialized RSATask. All chemistry-specific
+    # customization (schema, formatter, validator) is on RetroRSATask.
+    rsa_task = RetroRSATask(
+        n=rsa_n,
+        k=rsa_k,
+        t=rsa_t,
+        user_prompt=user_prompt_with_rag,
+        system_prompt=system_prompt,
+        proposal_prompt=proposal_prompt,
+        aggregation_prompt=aggregation_prompt,
+        parallel=True,
+        log_dir=None,  # auto-generate timestamp-based directory
+        server_urls=available_tools,
+        builtin_tools=builtin_tools_filtered,
+        bearer_token=tool_runtime.bearer_token,
+    )
+
+    rsa_log_dir = rsa_task.log_dir
+    await clogger.info(f"RSA execution logs will be saved to: {rsa_log_dir}")
+
+    if db_results_to_save:
+        try:
+            with open(f"{rsa_log_dir}/database_query_results.json", "w") as f:
+                json.dump(db_results_to_save, f, indent=2)
+            await clogger.info(
+                f"Database query results saved to {rsa_log_dir}/database_query_results.json"
+            )
+        except Exception as e:
+            await clogger.warning(f"Failed to save database results: {str(e)}")
+
+    # Runner factory for parallel execution: independent runner + callback per proposal.
+    proposal_counter = [0]
+
+    def create_runner():
+        proposal_counter[0] += 1
+        independent_callback = CallbackHandler(
+            websocket=websocket, name=f"proposal_{proposal_counter[0]}"
+        )
+        return experiment.create_agent_with_experiment_state(
+            task=None,
+            agent_name=f"retrosynth_{node_id}_proposal_{proposal_counter[0]}",
+            callback=independent_callback,
+        )
+
+    output, final_result = await rsa_task.run(
+        runner,
+        runner_factory=create_runner,
+        log_progress=log_progress,
+        logger_info=clogger.info,
+        logger_warning=clogger.warning,
+        logger_error=clogger.error,
+        callback_handler=(
+            callback_handler
+            if isinstance(callback_handler, CallbackHandler)
+            else None
+        ),
+    )
+
+    await clogger.info(
+        f"RSA mode completed successfully. Logs saved to: {rsa_log_dir}"
+    )
+
+    return output, final_result

--- a/charge_backend/retrosynthesis/prompts/rsa_rag_aggregation.txt
+++ b/charge_backend/retrosynthesis/prompts/rsa_rag_aggregation.txt
@@ -1,0 +1,27 @@
+You are given a chemistry task prompt and several candidate retrosynthesis solutions that may include insights from a reaction database.
+
+Original task:
+{original_prompt}
+
+Candidate solutions (Step {step} of {total_steps}):
+{candidates}
+
+Your task:
+- Review all candidate solutions carefully, including any database-informed insights
+- Identify portions of the reasoning that are chemically sound
+- Look for common patterns or complementary insights across candidates
+- Consider database evidence as supporting information, not absolute rules
+- Synthesize this information to produce a single, high-quality, chemically correct retrosynthesis
+
+Requirements:
+- Prefer candidates with more plausible chemistry over those with errors
+- Use database patterns as evidence, but validate with chemistry principles
+- Reject patterns that violate valence, require impossible reagents, or imply implausible bond changes
+- Ensure your output is a valid single-step retrosynthesis
+- Make sure all SMILES strings are valid
+- Verify that the reactants can plausibly produce the target molecule
+
+Output a single improved retrosynthesis solution with:
+- A reasoning summary explaining your aggregated approach
+- A list of reactant SMILES strings
+- A list of product SMILES strings (the target molecule)

--- a/charge_backend/retrosynthesis/prompts/rsa_rag_proposal.txt
+++ b/charge_backend/retrosynthesis/prompts/rsa_rag_proposal.txt
@@ -1,0 +1,18 @@
+Your task is to provide a retrosynthetic pathway for the target molecule. Database results showing similar reactions are already provided in the user prompt below - do NOT use the query_reaction_database tool as the query has already been performed.
+
+Reason using the provided database results and retrosynthesis principles:
+- Use database results as supporting evidence, but do NOT assume the closest-looking example is correct
+- Propose a chemically plausible disconnection based on the database patterns and your chemistry knowledge
+- Use functional group interconversion (FGI) only when justified
+- Ensure synthons/synthetic equivalents are realistic
+- Respect protecting group logic when needed
+- Avoid implausible bond disconnections (wrong polarity, impossible leaving groups, severe strain)
+- Prefer chemically plausible outcomes over superficial similarity
+- Reject patterns that would violate valence, require impossible reagents, or imply implausible bond changes
+
+Perform only single step retrosynthesis. Make sure the SMILES strings are valid. Use tools to verify the SMILES strings and diagnose any issues that arise.
+
+Your output should include:
+- A reasoning summary explaining your retrosynthetic approach (including insights from the database)
+- A list of reactant SMILES strings
+- A list of product SMILES strings (the target molecule)

--- a/charge_backend/retrosynthesis/prompts/rsa_rag_system.txt
+++ b/charge_backend/retrosynthesis/prompts/rsa_rag_system.txt
@@ -1,0 +1,1 @@
+You are an expert chemist specializing in retrosynthesis with access to a reaction database.

--- a/charge_backend/retrosynthesis/prompts/rsa_standalone_aggregation.txt
+++ b/charge_backend/retrosynthesis/prompts/rsa_standalone_aggregation.txt
@@ -1,0 +1,24 @@
+You are given a chemistry task prompt and several candidate retrosynthesis solutions.
+
+Original task:
+{original_prompt}
+
+Candidate solutions (Step {step} of {total_steps}):
+{candidates}
+
+Your task:
+- Review all candidate solutions carefully
+- Identify portions of the reasoning that are chemically sound
+- Look for common patterns or complementary insights across candidates
+- Synthesize this information to produce a single, high-quality, chemically correct retrosynthesis
+
+Requirements:
+- Prefer candidates with more plausible chemistry over those with errors
+- Ensure your output is a valid single-step retrosynthesis
+- Make sure all SMILES strings are valid
+- Verify that the reactants can plausibly produce the target molecule
+
+Output a single improved retrosynthesis solution with:
+- A reasoning summary explaining your aggregated approach
+- A list of reactant SMILES strings
+- A list of product SMILES strings (the target molecule)

--- a/charge_backend/retrosynthesis/prompts/rsa_standalone_proposal.txt
+++ b/charge_backend/retrosynthesis/prompts/rsa_standalone_proposal.txt
@@ -1,0 +1,15 @@
+Your task is to provide a retrosynthetic pathway for the target molecule. Reason using retrosynthesis principles:
+- Propose a chemically plausible disconnection
+- Use functional group interconversion (FGI) only when justified
+- Ensure synthons/synthetic equivalents are realistic
+- Respect protecting group logic when needed
+- Avoid implausible bond disconnections (wrong polarity, impossible leaving groups, severe strain)
+- Avoid violating valence/charges
+- Prefer chemically plausible precursor sets over superficial similarity
+
+Perform only single step retrosynthesis. Make sure the SMILES strings are valid. Use tools to verify the SMILES strings and diagnose any issues that arise.
+
+Your output should include:
+- A reasoning summary explaining your retrosynthetic approach
+- A list of reactant SMILES strings
+- A list of product SMILES strings (the target molecule)

--- a/charge_backend/retrosynthesis/prompts/rsa_standalone_system.txt
+++ b/charge_backend/retrosynthesis/prompts/rsa_standalone_system.txt
@@ -1,0 +1,1 @@
+You are an expert chemist specializing in retrosynthesis.

--- a/charge_backend/retrosynthesis/retrosynthesis_task.py
+++ b/charge_backend/retrosynthesis/retrosynthesis_task.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from pydantic import BaseModel, field_validator
 from flask_tools.chemistry.smarts_reactions_utils import verify_reaction_SMARTS
 from flask_tools.chemistry.smiles_utils import verify_smiles
+from pathlib import Path
 
 
 class ReactionOutputSchema(BaseModel):

--- a/charge_backend/retrosynthesis/template.py
+++ b/charge_backend/retrosynthesis/template.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 from fastapi import WebSocket
 from charge_backend.retrosynthesis import aizynth_tools as azf
@@ -11,6 +12,7 @@ from charge_backend.backend_helper_funcs import (
     ReactionAlternative,
     PathwayStep,
     FlaskRunSettings,
+    build_root_node,
 )
 from charge_backend.retrosynthesis.context import RetrosynthesisContext
 from charge_backend.moleculedb.molecule_naming import (
@@ -205,6 +207,14 @@ async def run_retro_planner(
     :return: A 2-tuple of (Reaction object, list of routes) if routes found, or
              ``(None, [])`` if nothing was discovered.
     """
+    # Check if config file exists
+    if not os.path.exists(config_file):
+        await clogger.info(
+            f"Template-based retrosynthesis config not found at {config_file}. "
+            "Template search unavailable."
+        )
+        return None, []
+
     await clogger.info(f"Running RetroPlanner for SMILES: {smiles}")
     report_init = False
     if azf.RetroPlanner.finder is None:
@@ -274,30 +284,7 @@ async def template_based_retrosynthesis(
     clogger = CallbackLogger(websocket, source="template_based_retrosynthesis")
     await clogger.info(f"Planning retrosynthesis for: `{start_smiles}`.")
 
-    # Generate root node
-    mol_sources = is_purchasable(start_smiles)
-    if mol_sources:
-        purchasable_str = f"Yes (via {', '.join(mol_sources)})"
-    else:
-        purchasable_str = "No"
-    root = Node(
-        id="node_0",
-        smiles=start_smiles,
-        label=smiles_to_html(start_smiles, run_settings.molecule_name_format),
-        hoverInfo=f"""# Root molecule
-**SMILES:** {start_smiles}
-
-**Purchasable**? {purchasable_str}""",
-        level=0,
-        parentId=None,
-        cost=None,
-        bandgap=None,
-        yield_=None,
-        purchasable=(len(mol_sources) > 0),
-        highlight="yellow",
-        x=100,
-        y=100,
-    )
+    root = build_root_node(start_smiles, run_settings)
     context.reset()  # Clear context
     await context.add_node(root, websocket=websocket)
 

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -390,6 +390,16 @@ const ChemistryTool: React.FC = () => {
   );
   const [debugModalMinimized, setDebugModalMinimized] = useState<boolean>(false);
 
+  // Retrosynthesis approach
+  const [aiOnly, setAiOnly] = useState<boolean>(true);
+
+  // RSA settings
+  const [useRsa, setUseRsa] = useState<boolean>(false);
+  const [rsaMode, setRsaMode] = useState<'standalone' | 'rag'>('standalone');
+  const [rsaN, setRsaN] = useState<number>(8);
+  const [rsaK, setRsaK] = useState<number>(4);
+  const [rsaT, setRsaT] = useState<number>(3);
+
   // Function to refresh tools list from backend
   const refreshToolsList = useCallback(() => {
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
@@ -926,9 +936,15 @@ const ChemistryTool: React.FC = () => {
       customPropertyAscending,
       systemPrompt,
       userPrompt: problemPrompt,
+      aiOnly,
       runSettings: {
         promptDebugging: debugMode,
         moleculeName: orchestratorSettings.moleculeName || 'brand',
+        useRsa,
+        rsaMode,
+        rsaN,
+        rsaK,
+        rsaT,
       },
       customization,
       ...(problemType === 'custom' && customPromptAttachments.length > 0
@@ -1619,13 +1635,18 @@ const ChemistryTool: React.FC = () => {
         runSettings: {
           promptDebugging: debugMode,
           moleculeName: orchestratorSettings.moleculeName || 'brand',
+          useRsa,
+          rsaMode,
+          rsaN,
+          rsaK,
+          rsaT,
         },
         ...data,
       };
       wsRef.current.send(JSON.stringify(msg));
       setContextMenu({ node: null, isReaction: false, x: 0, y: 0 });
     },
-    [debugMode, orchestratorSettings]
+    [debugMode, orchestratorSettings, useRsa, rsaMode, rsaN, rsaK, rsaT]
   );
 
   const handleReferenceDocumentSave = useCallback(
@@ -1723,6 +1744,11 @@ const ChemistryTool: React.FC = () => {
               runSettings: {
                 promptDebugging: debugMode,
                 moleculeName: orchestratorSettings.moleculeName || 'brand',
+                useRsa,
+                rsaMode,
+                rsaN,
+                rsaK,
+                rsaT,
               },
             })
           );
@@ -1730,8 +1756,8 @@ const ChemistryTool: React.FC = () => {
       }
       setIsComputing(true);
     },
-    [selectedReactionNode?.id, debugMode, orchestratorSettings]
-  ); // Only depend on the ID
+    [selectedReactionNode?.id, debugMode, orchestratorSettings, useRsa, rsaMode, rsaN, rsaK, rsaT]
+  );
 
   const stableAlternatives = useMemo(() => {
     return selectedReactionNode?.reaction?.alternatives || [];
@@ -1779,9 +1805,15 @@ const ChemistryTool: React.FC = () => {
       smiles: customQueryModal?.smiles,
       query: customQueryText,
       attachments: customQueryAttachments,
+      aiOnly,
       runSettings: {
         promptDebugging: debugMode,
         moleculeName: orchestratorSettings.moleculeName || 'brand',
+        useRsa,
+        rsaMode,
+        rsaN,
+        rsaK,
+        rsaT,
       },
       ...propertyDetails,
     };
@@ -2945,6 +2977,19 @@ const ChemistryTool: React.FC = () => {
         referenceUploadDisabled={!wsConnected}
         onReferenceDocumentSave={handleReferenceDocumentSave}
         showOptimizationTab={problemType === 'optimization'}
+        showRetrosynthesisTab={problemType === 'retrosynthesis'}
+        aiOnly={aiOnly}
+        onAiOnlyChange={setAiOnly}
+        useRsa={useRsa}
+        onUseRsaChange={setUseRsa}
+        rsaMode={rsaMode}
+        onRsaModeChange={setRsaMode}
+        rsaN={rsaN}
+        onRsaNChange={setRsaN}
+        rsaK={rsaK}
+        onRsaKChange={setRsaK}
+        rsaT={rsaT}
+        onRsaTChange={setRsaT}
       />
 
       {/* Prompt Debugging Modal */}

--- a/flask-app/src/components/combined_customization_modal.tsx
+++ b/flask-app/src/components/combined_customization_modal.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { BookOpen, FileText, X, Wrench, Network, FlaskConical } from 'lucide-react';
+import { BookOpen, FileText, X, Wrench, Network, FlaskConical, TestTubeDiagonal } from 'lucide-react';
 import { AttachmentUpload } from 'lc-conductor';
 import type { AgentAttachment } from 'lc-conductor';
 import { OptimizationCustomization, PdfReferenceMetadata, SelectableTool } from '../types';
 import { ToolSelectionContent } from './tool_selection_content';
 import { OptimizationCustomizationContent } from './optimization_customization_content';
 import { MoleculePropertiesContent } from './molecule_properties';
+import { RetrosynthesisCustomizationContent } from './retrosynthesis_customization_content';
 
 interface CombinedCustomizationModalProps {
   isOpen: boolean;
@@ -33,11 +34,27 @@ interface CombinedCustomizationModalProps {
   referenceUploadDisabled?: boolean;
   onReferenceDocumentSave?: (reference: AgentAttachment | null | undefined) => void | Promise<void>;
 
+  // Retrosynthesis settings props
+  aiOnly?: boolean;
+  onAiOnlyChange?: (value: boolean) => void;
+  useRsa?: boolean;
+  onUseRsaChange?: (value: boolean) => void;
+  rsaMode?: 'standalone' | 'rag';
+  onRsaModeChange?: (mode: 'standalone' | 'rag') => void;
+  rsaN?: number;
+  onRsaNChange?: (value: number) => void;
+  rsaK?: number;
+  onRsaKChange?: (value: number) => void;
+  rsaT?: number;
+  onRsaTChange?: (value: number) => void;
+
   // Show optimization tab only for optimization problem type
   showOptimizationTab?: boolean;
+  // Show retrosynthesis tab only for retrosynthesis problem type
+  showRetrosynthesisTab?: boolean;
 }
 
-type TabType = 'tools' | 'optimization' | 'molecule' | 'references';
+type TabType = 'tools' | 'optimization' | 'molecule' | 'references' | 'retrosynthesis';
 
 const sizeLabel = (sizeBytes: number): string => {
   if (sizeBytes < 1024 * 1024) {
@@ -64,7 +81,20 @@ const CombinedCustomizationModalContent: React.FC<CombinedCustomizationModalProp
   referenceDocument,
   referenceUploadDisabled = false,
   onReferenceDocumentSave,
+  aiOnly = true,
+  onAiOnlyChange,
+  useRsa = false,
+  onUseRsaChange,
+  rsaMode = 'standalone',
+  onRsaModeChange,
+  rsaN = 8,
+  onRsaNChange,
+  rsaK = 4,
+  onRsaKChange,
+  rsaT = 3,
+  onRsaTChange,
   showOptimizationTab = true,
+  showRetrosynthesisTab = false,
 }) => {
   const [activeTab, setActiveTab] = useState<TabType>('tools');
   const [pendingCustomization, setPendingCustomization] =
@@ -158,6 +188,25 @@ const CombinedCustomizationModalContent: React.FC<CombinedCustomizationModalProp
             )}
           </button>
 
+          {showRetrosynthesisTab && (
+            <button
+              onClick={() => setActiveTab('retrosynthesis')}
+              className={`flex items-center gap-2 px-6 py-3 font-medium transition-colors border-b-2 ${
+                activeTab === 'retrosynthesis'
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-secondary hover:text-primary'
+              }`}
+            >
+              <TestTubeDiagonal className="w-4 h-4" />
+              Retrosynthesis
+              {useRsa && (
+                <span className="ml-1 px-2 py-0.5 text-xs rounded-full bg-primary/20 text-primary">
+                  RSA
+                </span>
+              )}
+            </button>
+          )}
+
           {showOptimizationTab && (
             <button
               onClick={() => setActiveTab('optimization')}
@@ -216,6 +265,30 @@ const CombinedCustomizationModalContent: React.FC<CombinedCustomizationModalProp
               onSelectionChange={onToolSelectionChange}
             />
           )}
+
+          {activeTab === 'retrosynthesis' &&
+            showRetrosynthesisTab &&
+            onAiOnlyChange &&
+            onUseRsaChange &&
+            onRsaModeChange &&
+            onRsaNChange &&
+            onRsaKChange &&
+            onRsaTChange && (
+              <RetrosynthesisCustomizationContent
+                aiOnly={aiOnly}
+                onAiOnlyChange={onAiOnlyChange}
+                useRsa={useRsa}
+                onUseRsaChange={onUseRsaChange}
+                rsaMode={rsaMode}
+                onRsaModeChange={onRsaModeChange}
+                rsaN={rsaN}
+                onRsaNChange={onRsaNChange}
+                rsaK={rsaK}
+                onRsaKChange={onRsaKChange}
+                rsaT={rsaT}
+                onRsaTChange={onRsaTChange}
+              />
+            )}
 
           {activeTab === 'optimization' && showOptimizationTab && (
             <OptimizationCustomizationContent

--- a/flask-app/src/components/retrosynthesis_customization_content.tsx
+++ b/flask-app/src/components/retrosynthesis_customization_content.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { RsaSettingsPanel } from 'lc-conductor';
+
+interface RetrosynthesisCustomizationContentProps {
+  aiOnly: boolean;
+  onAiOnlyChange: (value: boolean) => void;
+  useRsa: boolean;
+  onUseRsaChange: (value: boolean) => void;
+  rsaMode: 'standalone' | 'rag';
+  onRsaModeChange: (mode: 'standalone' | 'rag') => void;
+  rsaN: number;
+  onRsaNChange: (value: number) => void;
+  rsaK: number;
+  onRsaKChange: (value: number) => void;
+  rsaT: number;
+  onRsaTChange: (value: number) => void;
+}
+
+export const RetrosynthesisCustomizationContent: React.FC<
+  RetrosynthesisCustomizationContentProps
+> = ({
+  aiOnly,
+  onAiOnlyChange,
+  useRsa,
+  onUseRsaChange,
+  rsaMode,
+  onRsaModeChange,
+  rsaN,
+  onRsaNChange,
+  rsaK,
+  onRsaKChange,
+  rsaT,
+  onRsaTChange,
+}) => {
+  return (
+    <div className="space-y-6">
+      {/* Use AI-based Approach */}
+      <div className="glass-panel">
+        <div className="flex items-start gap-4">
+          <input
+            type="checkbox"
+            checked={aiOnly}
+            onChange={(e) => onAiOnlyChange(e.target.checked)}
+            className="form-checkbox mt-1"
+            id="use-ai-based"
+          />
+          <div className="flex-1">
+            <label htmlFor="use-ai-based" className="form-label-block cursor-pointer">
+              Use AI-based Approach
+            </label>
+            <p className="text-sm text-tertiary mt-1">
+              Use AI-based retrosynthesis instead of template-based methods. AI models can suggest
+              novel reaction pathways beyond known templates.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Enable RSA Mode - Available independently */}
+      <RsaSettingsPanel
+        useRsa={useRsa}
+        onUseRsaChange={onUseRsaChange}
+        rsaMode={rsaMode}
+        onRsaModeChange={onRsaModeChange}
+        rsaN={rsaN}
+        onRsaNChange={onRsaNChange}
+        rsaK={rsaK}
+        onRsaKChange={onRsaKChange}
+        rsaT={rsaT}
+        onRsaTChange={onRsaTChange}
+      />
+
+      {/* Information Panel */}
+      <div className="glass-panel bg-primary/5 border border-primary/20">
+        <div className="text-sm text-secondary">
+          <p className="font-semibold mb-2">About Retrosynthesis Approaches:</p>
+          <ul className="list-disc list-inside space-y-1 text-xs text-tertiary">
+            <li>
+              <strong>AI-based:</strong> Uses neural networks to suggest novel reactions and
+              pathways not found in databases
+            </li>
+            <li>
+              <strong>Template-based (disabled):</strong> Uses known reaction patterns from chemical
+              databases
+            </li>
+            <li>RSA can be used with either approach for enhanced optimization</li>
+            <li>Template-based is more conservative but limited to known chemistry</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/flask-app/src/types.ts
+++ b/flask-app/src/types.ts
@@ -93,6 +93,11 @@ export type MoleculeNameFormat = 'brand' | 'iupac' | 'formula' | 'smiles';
 export interface FlaskRunSettings {
   moleculeName: MoleculeNameFormat;
   promptDebugging: boolean;
+  useRsa?: boolean;
+  rsaMode?: 'standalone' | 'rag';
+  rsaN?: number;
+  rsaK?: number;
+  rsaT?: number;
 }
 
 import type {


### PR DESCRIPTION
## Summary
  Integrate ChARGe RSA into FLASK-Copilot retrosynthesis, with consolidated flag handling, extracted RSA driver, and shared root-node creation. Addresses all PR review comments.

  ## Changes

  **Backend**
  - New file `charge_backend/retrosynthesis/ai_rsa.py` — chemistry-specific RSA driver wrapping ChARGe's `RSATask` via a
  `RetroRSATask` subclass (overrides `format_candidates`, `validate_proposal`)
  - `ai_based_retrosynthesis` gains `root_smiles: Optional[str] = None` — creates the root Node itself when called from `compute`;
  `db_then_ai_retrosynthesis` path unchanged
  - New helper `build_root_node(smiles, run_settings) -> Node` in `backend_helper_funcs.py`, reused by
  `template_based_retrosynthesis` (dedupe)
  - Drop `FlaskRunSettings.use_ai_based`; everything reads `data.get("aiOnly", True)` at the top level of the WS payload
  - Drop redundant `os.path.exists(config_file)` checks in `ai.py` and `backend_manager.py`; the consolidated check now lives only
  in `template.py:run_retro_planner`
  - Surface a `clogger.warning(...)` when the model returns no reactants (refusal indicator)
  - Unhighlight reactant node when template expansion is skipped (avoid stuck-yellow UI)

  **Frontend (`flask-app`)**
  - State rename `useAiBased` → `aiOnly`; sent at top level of compute / custom-query / compute-reaction-from payloads (always
  passed)
  - Updated `combined_customization_modal.tsx`, `retrosynthesis_customization_content.tsx`, `types.ts` accordingly
  - `retrosynthesis_customization_content.tsx` imports `RsaSettingsPanel` from `lc-conductor` (single source of truth)
  - Revert `package-lock.json` and `.gitignore` to upstream main (per review)

  **Prompts** (`charge_backend/retrosynthesis/prompts/`)
  - 3-part chemistry prompts for both RAG and standalone modes: `rsa_{mode}_system.txt`, `rsa_{mode}_proposal.txt`,
  `rsa_{mode}_aggregation.txt`

  ## Modes
  - **Standalone:** pure chemistry reasoning, `query_reaction_database` removed from tools
  - **RAG:** queries the reaction DB once, injects results into all proposal prompts; tool removed afterward

  ## Testing
  - Server boots; HTTP 200; all import sanity passes
  - AI-only, RSA-standalone, and RSA-RAG verified end-to-end on caffeine
  - Template mode verified against local `test_reactions.db`
  - pytest `charge_backend/tests/test_websocket_callbacks.py` 2/2

  ## Dependencies
  - **FLASK-LLNL/ChARGe#124** must merge first (this PR imports `RSATask` from `charge.algorithms`)
  - **FLASK-LLNL/LC-Conductor#15** must merge before this PR's submodule pointer can be cleanly bumped on `FLASK-LLNL/main`

  ## Related
  - Closes #190 (superseded)