### PR TITLE
Bug fix: can now see exact templates in Synthesis Pathway sidebar

### DIFF
--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -358,6 +358,7 @@ class FlaskActionManager(ActionManager):
                 f"Cannot find parent reaction for node {data['nodeId']}", source="Agent"
             )
             await self.websocket.send_json({"type": "complete"})
+            return
 
         parent_nodeid = self.retro_synth_context.parents[data["nodeId"]]
         parent_node = self.retro_synth_context.node_ids[parent_nodeid]

--- a/charge_backend/retrosynthesis/database.py
+++ b/charge_backend/retrosynthesis/database.py
@@ -273,7 +273,7 @@ async def find_exact_reactions(
             pathway=pathway,
             hoverInfo=generate_hover_info(processed),
         )
-        alternatives.append(alt)
+        result.alternatives.append(alt)
 
         if i == 0:
             alt.status = "active"


### PR DESCRIPTION
pydantic dataclassses will copy things, so the alternatives list is not the same as results.alternatives.
Other:
Bug fix: handle_recompute_reaction will return early when data['nodeId'] is not in parents