### PR TITLE
Fleeting Sessions

### DIFF
--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -1,8 +1,8 @@
+import argparse
 from typing import Any, Optional
 from fastapi import WebSocket
 import asyncio
-import os
-from lc_conductor import ActionManager, TaskManager, CallbackLogger
+from lc_conductor import ActionManager, handles
 from lc_conductor import (
     BuiltinToolDefinition,
     ToolRuntime,
@@ -13,9 +13,7 @@ from charge.experiments.experiment import Experiment
 from charge.tasks.task import Task
 from charge_backend.backend_helper_funcs import (
     CallbackHandler,
-    PathwayStep,
     Reaction,
-    ReactionAlternative,
     FlaskRunSettings,
 )
 from charge_backend.retrosynthesis.context import RetrosynthesisContext
@@ -35,6 +33,7 @@ from charge_backend.prompt_debugger import debug_prompt
 from charge_backend.backend_helper_funcs import Node
 from charge_backend.attachments import image_refs, validate_image_attachments
 from charge_backend.pdf import PdfDocumentRegistry
+from charge_backend.builtin_tools import list_builtin_tool_definitions
 
 
 class FlaskActionManager(ActionManager):
@@ -42,24 +41,31 @@ class FlaskActionManager(ActionManager):
 
     def __init__(
         self,
-        task_manager: TaskManager,
-        experiment: Experiment,
-        args,
+        websocket: WebSocket,
+        args: argparse.Namespace,
         username: str,
         pdf_registry: Optional[PdfDocumentRegistry] = None,
         builtin_tool_definitions: Optional[list[BuiltinToolDefinition]] = None,
     ):
         super().__init__(
-            task_manager,
-            experiment,
+            websocket,
             args,
             username,
             builtin_tool_definitions=builtin_tool_definitions,
         )
         self.run_settings: FlaskRunSettings = FlaskRunSettings()
-        self.websocket = task_manager.websocket
         self.retro_synth_context: Optional[RetrosynthesisContext] = None
         self.pdf_registry = pdf_registry or PdfDocumentRegistry()
+        self.builtin_tool_definitions = (
+            builtin_tool_definitions or list_builtin_tool_definitions(self.pdf_registry)
+        )
+
+    async def cleanup(self):
+        """
+        Tears down the action manager
+        """
+        self.pdf_registry.cleanup()
+        await super().cleanup()
 
     def setup_retro_synth_context(self) -> None:
         if self.retro_synth_context is None:
@@ -116,10 +122,7 @@ class FlaskActionManager(ActionManager):
     def _with_document_reference_context(self, system_prompt: str) -> str:
         return f"{system_prompt}{self._document_reference_context()}"
 
-    async def handle_load_state(self, data, *args, **kwargs) -> None:
-        self.pdf_registry.clear(self.username)
-        await super().handle_load_state(data, *args, **kwargs)
-
+    @handles("configure-pdf-reference")
     async def handle_configure_pdf_reference(self, data: dict[str, Any]) -> None:
         reference = data.get("pdfReference")
         if reference is None:
@@ -174,6 +177,7 @@ class FlaskActionManager(ActionManager):
             }
         )
 
+    @handles("compute")
     async def handle_compute(self, data: dict) -> None:
         self.setup_run_settings(data)
         problem_type = data.get("problemType")
@@ -371,6 +375,7 @@ class FlaskActionManager(ActionManager):
 
         await self.task_manager.run_task(run_func())
 
+    @handles("compute-reaction-from")
     async def handle_compute_reaction_from(self, data: dict) -> None:
         """Handle compute-reaction-from action."""
         self.setup_run_settings(data)
@@ -437,6 +442,7 @@ class FlaskActionManager(ActionManager):
 
         asyncio.create_task(self.task_manager.run_task(run_func()))
 
+    @handles("compute-reaction-templates")
     async def handle_template_retrosynthesis(self, data: dict) -> None:
         """Handle compute-reaction-templates action."""
         self.setup_run_settings(data)
@@ -458,6 +464,7 @@ class FlaskActionManager(ActionManager):
 
         asyncio.create_task(self.task_manager.run_task(run_func()))
 
+    @handles("optimize-from")
     async def handle_optimize_from(self, data: dict) -> None:
         """Handle optimize-from action."""
         self.setup_run_settings(data)
@@ -494,6 +501,7 @@ class FlaskActionManager(ActionManager):
             )
         )
 
+    @handles("recompute-parent-reaction")
     async def handle_recompute_reaction(self, data: dict) -> None:
         """Handle recompute-reaction action."""
         self.setup_run_settings(data)
@@ -557,6 +565,7 @@ class FlaskActionManager(ActionManager):
 
         asyncio.create_task(self.task_manager.run_task(run_func()))
 
+    @handles("set-reaction-alternative")
     async def handle_set_reaction_alternative(self, data: dict) -> None:
         """Handle set-reaction-alternative action."""
         self.setup_run_settings(data)
@@ -583,11 +592,13 @@ class FlaskActionManager(ActionManager):
             node, alt, self.retro_synth_context, self.websocket
         )
 
+    @handles("ui-update-orchestrator-settings")
     async def handle_orchestrator_settings_update(self, data: dict) -> None:
         if "moleculeName" in data:
             self.run_settings.molecule_name_format = data["moleculeName"]
-        await ActionManager.handle_orchestrator_settings_update(self, data)
+        await super().handle_orchestrator_settings_update(data)
 
+    @handles("query-molecule")
     async def handle_custom_query_molecule(self, data: dict) -> None:
         """Handle a query on the given molecule."""
         self.setup_run_settings(data)
@@ -638,6 +649,7 @@ class FlaskActionManager(ActionManager):
 
         asyncio.create_task(self.task_manager.run_task(run_and_report()))
 
+    @handles("query-reaction")
     async def handle_custom_query_reaction(self, data: dict) -> None:
         """Handle a query on the reaction (from nodeId to its reactants)."""
         self.setup_run_settings(data)
@@ -747,6 +759,7 @@ class FlaskActionManager(ActionManager):
             reaction_str += f"\n\nReaction hover information:\n{hover_info}"
         return reaction_str
 
+    @handles("chat-agent")
     async def handle_chat_agent(self, data: dict[str, Any]) -> None:
         self.setup_run_settings(data)
         agent_key = str(data.get("agentKey") or "")
@@ -774,14 +787,7 @@ class FlaskActionManager(ActionManager):
             return
         raise ValueError(f"Unsupported chat agent key: {agent_key}")
 
-    async def handle_get_username(self, _: dict) -> None:
-        await self.websocket.send_json(
-            {
-                "type": "get-username-response",
-                "username": self.username,
-            }
-        )
-
+    @handles("load-context")
     async def handle_load_state(self, data: dict, *args, **kwargs) -> None:
         await super().handle_load_state(data, *args, **kwargs)
 

--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -90,7 +90,7 @@ class FlaskActionManager(ActionManager):
 
     def selected_tool_runtime(self) -> ToolRuntime:
         runtime = super().selected_tool_runtime()
-        if not self.pdf_registry.has_active_document(self.username):
+        if not self.pdf_registry.has_active_document():
             return runtime
         if any(tool.identifier == "consult_with_document" for tool in runtime.tools):
             return runtime
@@ -109,7 +109,7 @@ class FlaskActionManager(ActionManager):
         return partial(self.send_agent_update, agent_key, debug=bool(data.get("debug")))
 
     def _document_reference_context(self) -> str:
-        metadata = self.pdf_registry.active_metadata(self.username)
+        metadata = self.pdf_registry.active_metadata()
         if metadata is None:
             return ""
         return (
@@ -126,7 +126,7 @@ class FlaskActionManager(ActionManager):
     async def handle_configure_pdf_reference(self, data: dict[str, Any]) -> None:
         reference = data.get("pdfReference")
         if reference is None:
-            self.pdf_registry.clear(self.username)
+            self.pdf_registry.clear()
             if data.get("silent"):
                 return
             await self.websocket.send_json(
@@ -140,7 +140,6 @@ class FlaskActionManager(ActionManager):
         try:
             metadata = await asyncio.to_thread(
                 self.pdf_registry.set_from_attachment,
-                self.username,
                 reference,
             )
         except ValueError as exc:

--- a/charge_backend/builtin_tools.py
+++ b/charge_backend/builtin_tools.py
@@ -11,21 +11,20 @@ from lc_conductor import (
 )
 
 
-def _document_consult_tool(registry: PdfDocumentRegistry, username: str):
+def _document_consult_tool(registry: PdfDocumentRegistry):
     async def consult_with_document(
         question: str,
         document_id: str | None = None,
         max_tool_calls: int = 14,
     ) -> str:
         """Consult the active uploaded PDF reference with a private subagent."""
-        return await registry.consult(username, question, document_id, max_tool_calls)
+        return await registry.consult(question, document_id, max_tool_calls)
 
     return consult_with_document
 
 
 def list_builtin_tool_definitions(
     pdf_registry: PdfDocumentRegistry | None = None,
-    username: str = "nobody",
 ) -> list[BuiltinToolDefinition]:
     definitions = [
         BuiltinToolDefinition(
@@ -54,7 +53,7 @@ def list_builtin_tool_definitions(
         ),
     ]
     if pdf_registry is not None:
-        consult_with_document = _document_consult_tool(pdf_registry, username)
+        consult_with_document = _document_consult_tool(pdf_registry)
         definitions.append(
             BuiltinToolDefinition(
                 identifier="consult_with_document",

--- a/charge_backend/charge_server.py
+++ b/charge_backend/charge_server.py
@@ -5,18 +5,17 @@
 ## SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-import asyncio
-from concurrent.futures import ProcessPoolExecutor
 from functools import partial
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Request
+from fastapi import FastAPI, WebSocket, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 import os
 import argparse
-import httpx
 import json
 from lc_conductor import try_get_public_hostname
+from lc_conductor.session import UserSessionManager
+from charge_backend.flask_session import FlaskUserSession
 import os
 
 from loguru import logger
@@ -27,7 +26,6 @@ from charge.clients.agent_factory import AgentFactory
 
 
 from lc_conductor.tool_registration import (
-    get_client_info,
     register_url,
     register_post,
     reload_server_list,
@@ -38,12 +36,6 @@ from lc_conductor.tool_registration import (
 )
 from lc_conductor import discover_models_endpoint, validate_initial_model
 
-from lc_conductor import TaskManager
-from lc_conductor.local_mcp_proxy import resolve_local_mcp_response
-from charge_backend.backend_manager import FlaskActionManager
-from charge_backend.builtin_tools import list_builtin_tool_definitions
-from charge_backend.pdf import PdfDocumentRegistry
-from charge_backend import prompt_debugger
 
 parser = argparse.ArgumentParser()
 
@@ -171,43 +163,6 @@ if os.path.exists(ASSETS_PATH):
         return HTMLResponse(html)
 
 
-async def _cancel_task_if_running(
-    action, task: asyncio.Task | None, executor: ProcessPoolExecutor | None
-):
-    if action not in [
-        "compute",
-        "optimize-from",
-        "compute-reaction-from",
-        "recompute-reaction",
-        "recompute-parent-reaction",
-    ]:
-        return
-
-    if task and not task.done():
-        logger.info("Cancelling existing compute task...")
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            logger.info("Previous compute task cancelled.")
-
-    if executor:
-        executor.shutdown(wait=False, cancel_futures=True)
-
-
-def _log_background_action_failure(task: asyncio.Task) -> None:
-    try:
-        exc = task.exception()
-    except asyncio.CancelledError:
-        logger.info("Background websocket action was cancelled")
-        return
-
-    if exc is None:
-        return
-
-    logger.exception(f"Background websocket action failed: {exc}")
-
-
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     logger.info(f"Request for websocket received. Headers: {str(websocket.headers)}")
@@ -218,6 +173,23 @@ async def websocket_endpoint(websocket: WebSocket):
 
     await websocket.accept()
 
+    # If an inactive session exists, attach to it
+    user_session = UserSessionManager.get_latest_inactive_session(username)
+    if user_session is not None:
+        await user_session.websocket.set_websocket(websocket)
+        logger.info("User session refreshed with new websocket")
+    else:
+        # Otherwise, create a new user session
+        user_session = FlaskUserSession(username, args, websocket)
+        UserSessionManager.add_session(username, user_session)
+        await user_session.event_loop()
+        logger.info("User session spawned in new thread")
+
+
+def register_agent_backend():
+    """
+    Handles ChARGe agent factory's initial model configuration
+    """
     API_KEY = os.getenv("FLASK_ORCHESTRATOR_API_KEY", None)
     model = os.getenv("FLASK_ORCHESTRATOR_MODEL", None)
     backend = os.getenv("FLASK_ORCHESTRATOR_BACKEND", None)
@@ -249,91 +221,6 @@ async def websocket_endpoint(websocket: WebSocket):
         ),
     )
 
-    # Set up an experiment class for current endpoint
-    experiment = Experiment(task=None)
-
-    task_manager = TaskManager(websocket)
-    pdf_registry = PdfDocumentRegistry()
-
-    action_manager = FlaskActionManager(
-        task_manager,
-        experiment,
-        args,
-        username,
-        pdf_registry=pdf_registry,
-        builtin_tool_definitions=list_builtin_tool_definitions(pdf_registry, username),
-    )
-    await action_manager.report_orchestrator_config()
-
-    action_handlers = {
-        # General actions
-        "query-molecule": action_manager.handle_custom_query_molecule,
-        "query-reaction": action_manager.handle_custom_query_reaction,
-        "compute": action_manager.handle_compute,
-        "reset": action_manager.handle_reset,
-        "stop": action_manager.handle_stop,
-        # Tools
-        "list-tools": action_manager.handle_list_tools,
-        "select-tools-for-task": action_manager.handle_select_tools_for_task,
-        "configure-pdf-reference": action_manager.handle_configure_pdf_reference,
-        # Settings
-        "ui-update-orchestrator-settings": action_manager.handle_orchestrator_settings_update,
-        "get-username": action_manager.handle_get_username,
-        "list-agents": action_manager.handle_list_agents,
-        "get-agent": action_manager.handle_get_agent,
-        "chat-agent": action_manager.handle_chat_agent,
-        # Context management
-        "save-context": action_manager.handle_save_state,
-        "load-context": action_manager.handle_load_state,
-        # Lead molecule optimization
-        "optimize-from": action_manager.handle_optimize_from,
-        # Retrosynthesis
-        "compute-reaction-from": action_manager.handle_compute_reaction_from,
-        "compute-reaction-templates": action_manager.handle_template_retrosynthesis,
-        "recompute-parent-reaction": action_manager.handle_recompute_reaction,
-        "set-reaction-alternative": action_manager.handle_set_reaction_alternative,
-    }
-
-    try:
-        while True:
-            try:
-                data = await websocket.receive_json()
-                action = data.get("action")
-
-                if action == "prompt-breakpoint-response":  # AI debugging
-                    prompt_debugger.DEBUG_PROMPT_RESPONSES[websocket].set_result(data)
-                    continue
-
-                if action == "local-mcp-response":
-                    if not resolve_local_mcp_response(websocket, data):
-                        logger.warning(f"Received unmatched local MCP response: {data}")
-                    continue
-
-                if action in action_handlers:
-                    handler_func = action_handlers[action]
-                    if action == "list-tools":
-                        task = asyncio.create_task(handler_func(data))
-                        task.add_done_callback(_log_background_action_failure)
-                    else:
-                        await handler_func(data)
-                else:
-                    logger.warning(
-                        f"Unknown action received: {action} with data {data}"
-                    )
-            except ValueError as e:
-                logger.error(f"Error in internal loop connection: {e}")
-
-    except WebSocketDisconnect:
-        logger.info("WebSocket disconnected")
-        pass
-    except httpx.ConnectError as e:
-        logger.error(f"Connection error: {e}")
-    except Exception as e:
-        logger.exception(f"Error in WebSocket connection: {e}")
-    finally:
-        pdf_registry.cleanup()
-        await task_manager.close()
-
 
 if __name__ == "__main__":
     import uvicorn
@@ -341,6 +228,8 @@ if __name__ == "__main__":
     host = args.host
     if host is None:
         _, host = try_get_public_hostname()
+
+    register_agent_backend()
 
     uvicorn.run(
         app,

--- a/charge_backend/charge_server.py
+++ b/charge_backend/charge_server.py
@@ -14,9 +14,10 @@ import os
 import argparse
 import json
 from lc_conductor import try_get_public_hostname
-from lc_conductor.session import UserSessionManager
+from lc_conductor.session import SessionTimedOut, UserSessionManager
 from charge_backend.flask_session import FlaskUserSession
 import os
+from typing import cast
 
 from loguru import logger
 from charge.clients.client import Client
@@ -35,7 +36,6 @@ from lc_conductor.tool_registration import (
     get_registered_servers,
 )
 from lc_conductor import discover_models_endpoint, validate_initial_model
-
 
 parser = argparse.ArgumentParser()
 
@@ -173,17 +173,34 @@ async def websocket_endpoint(websocket: WebSocket):
 
     await websocket.accept()
 
+    user_session: FlaskUserSession | None = cast(
+        FlaskUserSession | None,
+        UserSessionManager.get_latest_inactive_session(username),
+    )
+
     # If an inactive session exists, attach to it
-    user_session = UserSessionManager.get_latest_inactive_session(username)
     if user_session is not None:
-        await user_session.websocket.set_websocket(websocket)
-        logger.info("User session refreshed with new websocket")
-    else:
-        # Otherwise, create a new user session
+        # In a later PR, this branch will send the saved state back to the UI in
+        # order to resume the session. For now, we terminate the existing
+        # session.
+        await user_session.terminate()
+        user_session = None
+        # try:
+        #     await user_session.websocket.set_websocket(websocket)
+        #     logger.info("User session refreshed with new websocket")
+        # except SessionTimedOut:
+        #     await user_session.terminate()
+        #     user_session = None
+
+    # Otherwise, create a new user session.
+    if user_session is None:
         user_session = FlaskUserSession(username, args, websocket)
-        UserSessionManager.add_session(username, user_session)
+        logger.info("User session created")
+
+    try:
         await user_session.event_loop()
-        logger.info("User session spawned in new thread")
+    finally:
+        logger.info("User session websocket loop exited")
 
 
 def register_agent_backend():

--- a/charge_backend/flask_session.py
+++ b/charge_backend/flask_session.py
@@ -1,0 +1,74 @@
+###############################################################################
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC.
+## See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+###############################################################################
+"""
+Definition of a FLASK user session object.
+"""
+
+import argparse
+from typing import Any
+import uuid
+from fastapi import WebSocket
+from loguru import logger
+
+from lc_conductor.local_mcp_proxy import resolve_local_mcp_response
+from lc_conductor.session import UserSession
+
+from charge_backend.backend_manager import FlaskActionManager
+from charge_backend import prompt_debugger
+
+
+class FlaskUserSession(UserSession):
+    """
+    A representation of a persistent FLASK Copilot user session. Includes the
+    action manager, which in turn includes information about the currently-running
+    experiment, UI state, and AI agents and their context.
+    """
+
+    action_manager: FlaskActionManager
+
+    def __init__(
+        self, username: str, args: argparse.Namespace, websocket: WebSocket
+    ) -> None:
+        super().__init__(username, str(uuid.uuid4()), websocket, action_manager=None)
+
+        action_manager = FlaskActionManager(
+            self.websocket,
+            args,
+            username,
+        )
+        self.action_manager: FlaskActionManager = action_manager
+
+    async def event_loop(self):
+        # Before the event loop starts, synchronize the orchestrator model config
+        await self.action_manager.report_orchestrator_config()
+
+        # Run event loop normally
+        return await super().event_loop()
+
+    async def handle_action(self, action: str, data: dict[str, Any]):
+        """
+        Handles a received message from the FLASK Copilot Web UI.
+        First we look for prompt breakpoint and local MCP proxy responses,
+        because they are received on an asynchronous thread during an existing
+        request. Then, we try to dispatch from the FLASK Action Manager.
+
+        :param action: The name of the action to perform.
+        :param data: The JSON data received with the message.
+        """
+        if action == "prompt-breakpoint-response":  # AI debugging
+            prompt_debugger.DEBUG_PROMPT_RESPONSES[self.websocket].set_result(data)
+            return
+
+        if action == "local-mcp-response":
+            if not resolve_local_mcp_response(self.websocket, data):
+                logger.warning(f"Received unmatched local MCP response: {data}")
+            return
+
+        if not self.action_manager.has_handler(action):
+            logger.warning(f"Unknown action received: {action} with data {data}")
+
+        return await self.action_manager.dispatch(action, data)

--- a/charge_backend/pdf/registry.py
+++ b/charge_backend/pdf/registry.py
@@ -169,22 +169,25 @@ class PdfDocument:
 
 
 class PdfDocumentRegistry:
+    """
+    A document registry (metadata, summary, ToC) that caches previously uploaded
+    PDFs.
+    """
+
     def __init__(self, cache_dir: str | Path | None = None):
         self._base_dir = Path(cache_dir) if cache_dir else Path(tempfile.mkdtemp())
         self._base_dir.mkdir(parents=True, exist_ok=True)
-        self._documents: dict[str, PdfDocument] = {}  # Maps user to document
+        self._document: PdfDocument | None = None
 
-    def active_metadata(self, user: str) -> PdfReferenceMetadata | None:
-        if user not in self._documents:
+    def active_metadata(self) -> PdfReferenceMetadata | None:
+        if self._document is None:
             return None
-        return self._documents[user].metadata
+        return self._document.metadata
 
-    def has_active_document(self, user: str) -> bool:
-        return user in self._documents
+    def has_active_document(self) -> bool:
+        return self._document is not None
 
-    def set_from_attachment(
-        self, user: str, attachment: dict[str, Any]
-    ) -> PdfReferenceMetadata:
+    def set_from_attachment(self, attachment: dict[str, Any]) -> PdfReferenceMetadata:
         normalized = validate_pdf_reference(attachment)
         raw_bytes = _decode_data_url(normalized["dataUrl"])
         document_id = hashlib.sha256(raw_bytes).hexdigest()
@@ -208,40 +211,36 @@ class PdfDocumentRegistry:
             pageCount=overview.page_count,
             createdAt=normalized["createdAt"],
         )
-        self._documents[user] = PdfDocument(metadata, path, document)
+        self._document = PdfDocument(metadata, path, document)
         return metadata
 
-    def clear(self, user: str) -> None:
-        if user in self._documents:
-            del self._documents[user]
+    def clear(self) -> None:
+        self._document = None
 
     def cleanup(self) -> None:
-        self._documents.clear()
+        self._document = None
         shutil.rmtree(self._base_dir, ignore_errors=True)
 
     async def consult(
         self,
-        user: str,
         question: str,
         document_id: str | None = None,
         max_tool_calls: int = SUBAGENT_MAX_TOOL_CALLS,
     ) -> str:
-        if user not in self._documents:
+        if not self.has_active_document():
             return (
                 "No PDF reference is available in this session. Ask the user to "
                 "reupload the PDF in Customize > References before consulting it."
             )
-
-        active_id = self._documents[user].metadata.documentId
+        assert self._document is not None
+        active_id = self._document.metadata.documentId
         if document_id and document_id != active_id:
             return (
                 f"The requested PDF `{document_id}` is not active. The only active "
-                f"PDF is `{active_id}` ({self._documents[user].metadata.name})."
+                f"PDF is `{active_id}` ({self._document.metadata.name})."
             )
 
-        return await self._documents[user].consult(
-            question, max_tool_calls=max_tool_calls
-        )
+        return await self._document.consult(question, max_tool_calls=max_tool_calls)
 
 
 def validate_pdf_reference(attachment: dict[str, Any]) -> dict[str, Any]:

--- a/charge_backend/tests/test_agent_histories.py
+++ b/charge_backend/tests/test_agent_histories.py
@@ -18,14 +18,6 @@ class FakeWebSocket:
         self.last_payload = payload
 
 
-class FakeTaskManager:
-    def __init__(self, websocket):
-        self.websocket = websocket
-        self.configured_tool_servers = []
-        self.discovered_local_mcp_tools = {}
-        self.selected_tool_runtime = None
-
-
 class FakeAgent(Agent):
     def __init__(
         self,
@@ -53,10 +45,8 @@ class FakeAgent(Agent):
 
 def make_manager():
     websocket = FakeWebSocket()
-    task_manager = FakeTaskManager(websocket)
     manager = FlaskActionManager(
-        task_manager=task_manager,
-        experiment=Experiment(task=None),
+        websocket=websocket,
         args=SimpleNamespace(),
         username="test-user",
     )

--- a/charge_backend/tests/test_problem_context_lifecycle.py
+++ b/charge_backend/tests/test_problem_context_lifecycle.py
@@ -16,20 +16,10 @@ class FakeWebSocket:
         self.last_payload = payload
 
 
-class FakeTaskManager:
-    def __init__(self, websocket):
-        self.websocket = websocket
-        self.configured_tool_servers = []
-        self.discovered_local_mcp_tools = {}
-        self.selected_tool_runtime = None
-
-
 def make_manager():
     websocket = FakeWebSocket()
-    task_manager = FakeTaskManager(websocket)
     return FlaskActionManager(
-        task_manager=task_manager,
-        experiment=Experiment(task=None),
+        websocket=websocket,
         args=SimpleNamespace(),
         username="test-user",
     )

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -2045,7 +2045,7 @@ const ChemistryTool: React.FC = () => {
 
   const addSidebarMessage = (message: SidebarMessage): void => {
     message.id = message.id ?? Date.now();
-    message.timestamp = message.timestamp ?? new Date().toISOString();
+    message.timestamp = message.timestamp ?? Date.now();
     if (!message.source) {
       message.source = 'Backend';
     }

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -1174,7 +1174,10 @@ const ChemistryTool: React.FC = () => {
             break;
           }
           case 'response': {
-            addSidebarMessage(data.message!);
+            addSidebarMessage({
+              ...data.message!,
+              timestamp: data.message?.timestamp ?? data.timestamp,
+            });
             console.log('Server response:', data.message);
             break;
           }
@@ -2041,8 +2044,8 @@ const ChemistryTool: React.FC = () => {
   };
 
   const addSidebarMessage = (message: SidebarMessage): void => {
-    message.id = Date.now();
-    message.timestamp = new Date().toISOString();
+    message.id = message.id ?? Date.now();
+    message.timestamp = message.timestamp ?? new Date().toISOString();
     if (!message.source) {
       message.source = 'Backend';
     }

--- a/flask-app/src/types.ts
+++ b/flask-app/src/types.ts
@@ -193,6 +193,7 @@ export interface WebSocketMessageToServer {
 // Messages received from backend
 export interface WebSocketMessage {
   type: string;
+  timestamp?: string | number;
 
   node?: TreeNode;
   edge?: Edge;

--- a/flask-app/src/types.ts
+++ b/flask-app/src/types.ts
@@ -193,7 +193,7 @@ export interface WebSocketMessageToServer {
 // Messages received from backend
 export interface WebSocketMessage {
   type: string;
-  timestamp?: string | number;
+  timestamp?: number;
 
   node?: TreeNode;
   edge?: Edge;


### PR DESCRIPTION
This PR is the first tranche of work on refactoring Websocket sessions to persistent objects that outlive the connection. It is based on the changes in FLASK-LLNL/LC-Conductor#30, which includes more information as to what has changed.

Currently, the PR is focused on the refactoring and reconnecting will reinitialize a session. As we improve our serialization and data ownership across the frontends/backends, the reinitialization will no longer be necessary.

Specific FLASK Copilot changes include:
* Simplifying the PDF registry as it becomes session-owned
* Reducing duplicate code across LC Conductor and FLASK Copilot
* Refactoring initial agent setup to happen once upon server setup rather than with every connection
