### PR TITLE
Add partial retrosynthesis from reaction SMILES

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,10 @@
 ################################################################################
-## Copyright 2025 Lawrence Livermore National Security, LLC.
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC.
 ## See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0
 ################################################################################
-Copyright (c) 2025, Lawrence Livermore National Security, LLC.
+Copyright (c) 2025-2026, Lawrence Livermore National Security, LLC.
 Produced at the Lawrence Livermore National Laboratory.
 
 LLNL-CODE-2006345.

--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -27,6 +27,9 @@ from charge_backend.retrosynthesis.ai import (
     ai_based_retrosynthesis,
     db_then_ai_retrosynthesis,
 )
+from charge_backend.retrosynthesis.reaction_smiles import (
+    reaction_smiles_retrosynthesis,
+)
 from charge_backend.retrosynthesis.alternatives import set_reaction_alternative
 from charge_backend.prompt_debugger import debug_prompt
 from charge_backend.backend_helper_funcs import Node
@@ -326,14 +329,25 @@ class FlaskActionManager(ActionManager):
 
     async def _handle_retrosynthesis(self, data: dict) -> None:
         """Handle retrosynthesis problem type."""
-        run_func = partial(
-            template_based_retrosynthesis,
-            data["smiles"],
-            self.args.config_file,
-            self.get_retro_synth_context(),
-            self.task_manager.websocket,
-            self.run_settings,
-        )
+        # A reaction SMILES ("reactants>>products") is rendered directly as a
+        # one-step partial graph rather than searched with AiZynthFinder.
+        if ">>" in data["smiles"]:
+            run_func = partial(
+                reaction_smiles_retrosynthesis,
+                data["smiles"],
+                self.get_retro_synth_context(),
+                self.task_manager.websocket,
+                self.run_settings,
+            )
+        else:
+            run_func = partial(
+                template_based_retrosynthesis,
+                data["smiles"],
+                self.args.config_file,
+                self.get_retro_synth_context(),
+                self.task_manager.websocket,
+                self.run_settings,
+            )
 
         await self.task_manager.run_task(run_func())
 

--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -373,20 +373,35 @@ class FlaskActionManager(ActionManager):
             images=image_refs(attachments) if attachments else None,
         )
 
-        run_func = partial(
-            run_custom_problem,
-            data["smiles"],
-            self._with_document_reference_context(data["systemPrompt"]),
-            data["userPrompt"],
-            self.experiment,
-            tool_runtime,
-            self.task_manager.websocket,
-            self.run_settings,
-            attachments,
-            self._agent_update_callback("custom:main", data),
-        )
+        # A reaction SMILES ("reactants>>products" or "reactants>reagents>
+        # products") is rendered directly as a one-step partial graph before the
+        # agent runs. The agent still receives the full reaction SMILES for
+        # context, but must not rebuild node_0 from its response.
+        is_reaction = ">" in data["smiles"]
 
-        await self.task_manager.run_task(run_func())
+        async def run_custom() -> None:
+            if is_reaction:
+                await reaction_smiles_retrosynthesis(
+                    data["smiles"],
+                    self.get_retro_synth_context(),
+                    self.task_manager.websocket,
+                    self.run_settings,
+                    send_complete=False,
+                )
+            await run_custom_problem(
+                data["smiles"],
+                self._with_document_reference_context(data["systemPrompt"]),
+                data["userPrompt"],
+                self.experiment,
+                tool_runtime,
+                self.task_manager.websocket,
+                self.run_settings,
+                attachments,
+                self._agent_update_callback("custom:main", data),
+                build_nodes_from_response=not is_reaction,
+            )
+
+        await self.task_manager.run_task(run_custom())
 
     @handles("compute-reaction-from")
     async def handle_compute_reaction_from(self, data: dict) -> None:

--- a/charge_backend/backend_manager.py
+++ b/charge_backend/backend_manager.py
@@ -1,3 +1,10 @@
+################################################################################
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC..
+## See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 import argparse
 from typing import Any, Optional
 from fastapi import WebSocket
@@ -329,9 +336,12 @@ class FlaskActionManager(ActionManager):
 
     async def _handle_retrosynthesis(self, data: dict) -> None:
         """Handle retrosynthesis problem type."""
-        # A reaction SMILES ("reactants>>products") is rendered directly as a
-        # one-step partial graph rather than searched with AiZynthFinder.
-        if ">>" in data["smiles"]:
+        # A reaction SMILES (reactant '>' agent '>' product or
+        # reactants '>>' products) is rendered directly as a one-step
+        # partial graph rather than searched with
+        # template_based_retrosynthesis which includes both exact
+        # matches in local databases and template-based methods.
+        if ">" in data["smiles"]:
             run_func = partial(
                 reaction_smiles_retrosynthesis,
                 data["smiles"],

--- a/charge_backend/charge_backend_custom.py
+++ b/charge_backend/charge_backend_custom.py
@@ -20,6 +20,7 @@ async def run_custom_problem(
     run_settings: FlaskRunSettings,
     attachments: Optional[list[dict[str, object]]] = None,
     history_callback: Optional[Callable[[], Awaitable[None]]] = None,
+    build_nodes_from_response: bool = True,
 ):
     task = Task(
         system_prompt=system_prompt,
@@ -51,20 +52,23 @@ async def run_custom_problem(
         }
     )
 
-    # Find all SMILES values
-    matches = re.findall(r'"smiles":\s*"([^"]+)"', result)
+    # Find all SMILES values and build nodes from them, unless the caller has
+    # already populated the graph (e.g. a reaction-SMILES partial graph, whose
+    # node_0 would collide with the nodes created here).
+    if build_nodes_from_response:
+        matches = re.findall(r'"smiles":\s*"([^"]+)"', result)
 
-    if matches:
-        for i, smiles in enumerate(matches):
-            node = Node(
-                id=f"node_{i}",
-                smiles=smiles,
-                label=smiles_to_html(smiles, run_settings.molecule_name_format),
-                hoverInfo=result,
-                level=0,
-                x=50,
-                y=100 + i * 150,
-            )
-            await experiment.graph_context.add_node(node, websocket)
+        if matches:
+            for i, smiles in enumerate(matches):
+                node = Node(
+                    id=f"node_{i}",
+                    smiles=smiles,
+                    label=smiles_to_html(smiles, run_settings.molecule_name_format),
+                    hoverInfo=result,
+                    level=0,
+                    x=50,
+                    y=100 + i * 150,
+                )
+                await experiment.graph_context.add_node(node, websocket)
 
     await websocket.send_json({"type": "complete"})

--- a/charge_backend/charge_server.py
+++ b/charge_backend/charge_server.py
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2025 Lawrence Livermore National Security, LLC. and Binghamton University.
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC..
 ## See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/charge_backend/charge_server.py
+++ b/charge_backend/charge_server.py
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2025-2026 Lawrence Livermore National Security, LLC..
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC.
 ## See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/charge_backend/flask_experiment.py
+++ b/charge_backend/flask_experiment.py
@@ -379,12 +379,21 @@ class FlaskExperiment(Experiment):
 
         super().load_state(state)
 
-        # If we have an "old-style" serialization, we won't get the
-        # "graphContext", likely just "nodes" and "edges".
+        # Repopulate the EXISTING graph_context in place rather than replacing
+        # the object. Callers (e.g. get_retro_synth_context) hand out a
+        # reference to graph_context and then mutate it; swapping the object
+        # here would orphan those references and cause nodes to be written to a
+        # stale graph (observed as duplicated molecules in the custom flow).
         if "graphContext" in state:
-            # Preferring symmetry with GraphContext.save_state's impl
-            self.graph_context = GraphContext.model_validate(state.get("graphContext"))
+            loaded = GraphContext.model_validate(state.get("graphContext"))
+            self.graph_context.reset()
+            self.graph_context.node_ids.update(loaded.node_ids)
+            self.graph_context.parents.update(loaded.parents)
+            self.graph_context.edges.update(loaded.edges)
+            self.graph_context.nodes_per_level.update(loaded.nodes_per_level)
         else:
+            # Old-style serialization ("nodes"/"edges"); GraphContext.load_state
+            # already repopulates in place.
             self.graph_context.load_state(state)
 
     def reset(self):

--- a/charge_backend/flask_experiment.py
+++ b/charge_backend/flask_experiment.py
@@ -274,7 +274,16 @@ class GraphContext(BaseModel):
 
         return self.model_dump(mode="json")
 
-    def load_state(self, data: dict[str, Any]) -> None:
+    def _load_state_graph_context(self, data: dict[str, Any]) -> None:
+        """Restore context in-place."""
+        loaded = GraphContext.model_validate(data)
+        self.reset()
+        self.node_ids.update(loaded.node_ids)
+        self.parents.update(loaded.parents)
+        self.edges.update(loaded.edges)
+        self.nodes_per_level.update(loaded.nodes_per_level)
+
+    def _load_state_classic(self, data: dict[str, Any]) -> None:
         """Restore a context from a dictionary serialization.
         Existing state is clobbered, even if the dictionary
         serialization is empty or "node"-less.
@@ -345,6 +354,19 @@ class GraphContext(BaseModel):
 
             self._add_node(node, edge)
 
+    # Repopulate the EXISTING graph_context in place rather than replacing
+    # the object. Callers (e.g. get_retro_synth_context) hand out a
+    # reference to graph_context and then mutate it; swapping the object
+    # here would orphan those references and cause nodes to be written to a
+    # stale graph (observed as duplicated molecules in the custom flow).
+    def load_state(self, state: dict[str, Any]) -> None:
+        if "graphContext" in state:
+            self._load_state_graph_context(state.get("graphContext"))
+        else:
+            # Old-style serialization ("nodes"/"edges"); GraphContext.load_state
+            # already repopulates in place.
+            self._load_state_classic(state)
+
     def is_empty(self) -> bool:
         return len(self.node_ids) == 0
 
@@ -379,22 +401,7 @@ class FlaskExperiment(Experiment):
 
         super().load_state(state)
 
-        # Repopulate the EXISTING graph_context in place rather than replacing
-        # the object. Callers (e.g. get_retro_synth_context) hand out a
-        # reference to graph_context and then mutate it; swapping the object
-        # here would orphan those references and cause nodes to be written to a
-        # stale graph (observed as duplicated molecules in the custom flow).
-        if "graphContext" in state:
-            loaded = GraphContext.model_validate(state.get("graphContext"))
-            self.graph_context.reset()
-            self.graph_context.node_ids.update(loaded.node_ids)
-            self.graph_context.parents.update(loaded.parents)
-            self.graph_context.edges.update(loaded.edges)
-            self.graph_context.nodes_per_level.update(loaded.nodes_per_level)
-        else:
-            # Old-style serialization ("nodes"/"edges"); GraphContext.load_state
-            # already repopulates in place.
-            self.graph_context.load_state(state)
+        self.graph_context.load_state(state)
 
     def reset(self):
         super().reset()

--- a/charge_backend/moleculedb/purchasable.py
+++ b/charge_backend/moleculedb/purchasable.py
@@ -131,3 +131,16 @@ def is_purchasable(
             result.append("ZINC Stock")
 
     return result
+
+
+def purchasable_summary(mol_sources: list[str]) -> str:
+    """
+    Format the result of :func:`is_purchasable` as a human-readable string
+    for hover info and display.
+
+    :param mol_sources: List of purchase sources (as returned by is_purchasable).
+    :return: ``"Yes (via <sources>)"`` if any sources, otherwise ``"No"``.
+    """
+    if mol_sources:
+        return f"Yes (via {', '.join(mol_sources)})"
+    return "No"

--- a/charge_backend/rdkit_mol_differ.py
+++ b/charge_backend/rdkit_mol_differ.py
@@ -27,16 +27,21 @@ class ReactionAtomChanges:
 
 def parse_reaction_smiles(
     reaction_smiles: str,
-) -> Tuple[List[Chem.Mol], List[Chem.Mol]]:
+    *,
+    include_agents: bool = False,
+):
     """Parse reaction SMILES using RDKit's reaction parser.
 
     Supports both "reactants>>products" and "reactants>agents>products".
-    Agents are ignored.
+
+    :param include_agents: If False (default), returns ``(reactants, products)``
+        and agents are ignored. If True, returns ``(reactants, agents,
+        products)``.
     """
 
     s = (reaction_smiles or "").strip()
     if not s:
-        return [], []
+        return ([], [], []) if include_agents else ([], [])
 
     try:
         rxn = ReactionFromSmarts(str(s), useSmiles=True)
@@ -46,27 +51,30 @@ def parse_reaction_smiles(
     if rxn is None:
         raise ValueError(f"Invalid reaction SMILES: {s}")
 
-    reactants: List[Chem.Mol] = []
-    products: List[Chem.Mol] = []
+    def _templates(count: int, get, kind: str) -> List[Chem.Mol]:
+        mols: List[Chem.Mol] = []
+        for i in range(int(count)):
+            m0 = get(int(i))
+            if m0 is None:
+                raise ValueError(f"Invalid {kind} in reaction SMILES: {s}")
+            # Copy the template mol: RDKit reaction objects can own the
+            # underlying template storage; returning a view can lead to invalid
+            # mols once the reaction goes out of scope.
+            m = Chem.Mol(m0)
+            Chem.SanitizeMol(m)
+            mols.append(m)
+        return mols
 
-    for i in range(int(rxn.GetNumReactantTemplates())):
-        m0 = rxn.GetReactantTemplate(int(i))
-        if m0 is None:
-            raise ValueError(f"Invalid reactant in reaction SMILES: {s}")
-        # Copy the template mol: RDKit reaction objects can own the underlying
-        # template storage; returning a view can lead to invalid mols once the
-        # reaction goes out of scope.
-        m = Chem.Mol(m0)
-        Chem.SanitizeMol(m)
-        reactants.append(m)
+    reactants = _templates(
+        rxn.GetNumReactantTemplates(), rxn.GetReactantTemplate, "reactant"
+    )
+    products = _templates(
+        rxn.GetNumProductTemplates(), rxn.GetProductTemplate, "product"
+    )
 
-    for i in range(int(rxn.GetNumProductTemplates())):
-        m0 = rxn.GetProductTemplate(int(i))
-        if m0 is None:
-            raise ValueError(f"Invalid product in reaction SMILES: {s}")
-        m = Chem.Mol(m0)
-        Chem.SanitizeMol(m)
-        products.append(m)
+    if include_agents:
+        agents = _templates(rxn.GetNumAgentTemplates(), rxn.GetAgentTemplate, "agent")
+        return reactants, agents, products
 
     return reactants, products
 

--- a/charge_backend/rdkit_mol_differ.py
+++ b/charge_backend/rdkit_mol_differ.py
@@ -71,6 +71,10 @@ def _parse_reaction_smiles(
     return reactants, products
 
 
+# Public alias: other modules build partial graphs from reaction SMILES.
+parse_reaction_smiles = _parse_reaction_smiles
+
+
 def _ensure_mols(items: Sequence[object], *, label: str) -> List[Chem.Mol]:
     """Convert a list of SMILES strings / RDKit mols into RDKit mols."""
 

--- a/charge_backend/rdkit_mol_differ.py
+++ b/charge_backend/rdkit_mol_differ.py
@@ -25,7 +25,7 @@ class ReactionAtomChanges:
     reactant_mcs_smarts: List[Optional[str]]
 
 
-def _parse_reaction_smiles(
+def parse_reaction_smiles(
     reaction_smiles: str,
 ) -> Tuple[List[Chem.Mol], List[Chem.Mol]]:
     """Parse reaction SMILES using RDKit's reaction parser.
@@ -69,10 +69,6 @@ def _parse_reaction_smiles(
         products.append(m)
 
     return reactants, products
-
-
-# Public alias: other modules build partial graphs from reaction SMILES.
-parse_reaction_smiles = _parse_reaction_smiles
 
 
 def _ensure_mols(items: Sequence[object], *, label: str) -> List[Chem.Mol]:
@@ -851,7 +847,7 @@ def reaction_atom_changes(
 ) -> ReactionAtomChanges:
     """Identify changed atoms for reaction SMILES: reactants>>products."""
 
-    reactants, products = _parse_reaction_smiles(reaction_smiles)
+    reactants, products = parse_reaction_smiles(reaction_smiles)
     return _reaction_atom_changes_mols(
         reactants, products, mcs_timeout_s=int(mcs_timeout_s)
     )

--- a/charge_backend/rdkit_mol_differ.py
+++ b/charge_backend/rdkit_mol_differ.py
@@ -28,20 +28,20 @@ class ReactionAtomChanges:
 def parse_reaction_smiles(
     reaction_smiles: str,
     *,
-    include_agents: bool = False,
+    include_reagents: bool = False,
 ):
     """Parse reaction SMILES using RDKit's reaction parser.
 
-    Supports both "reactants>>products" and "reactants>agents>products".
+    Supports both "reactants>>products" and "reactants>reagents>products".
 
-    :param include_agents: If False (default), returns ``(reactants, products)``
-        and agents are ignored. If True, returns ``(reactants, agents,
+    :param include_reagents: If False (default), returns ``(reactants, products)``
+        and reagents are ignored. If True, returns ``(reactants, reagents,
         products)``.
     """
 
     s = (reaction_smiles or "").strip()
     if not s:
-        return ([], [], []) if include_agents else ([], [])
+        return ([], [], []) if include_reagents else ([], [])
 
     try:
         rxn = ReactionFromSmarts(str(s), useSmiles=True)
@@ -72,9 +72,11 @@ def parse_reaction_smiles(
         rxn.GetNumProductTemplates(), rxn.GetProductTemplate, "product"
     )
 
-    if include_agents:
-        agents = _templates(rxn.GetNumAgentTemplates(), rxn.GetAgentTemplate, "agent")
-        return reactants, agents, products
+    if include_reagents:
+        reagents = _templates(
+            rxn.GetNumAgentTemplates(), rxn.GetAgentTemplate, "reagent"
+        )
+        return reactants, reagents, products
 
     return reactants, products
 

--- a/charge_backend/retrosynthesis/ai.py
+++ b/charge_backend/retrosynthesis/ai.py
@@ -22,7 +22,10 @@ from charge_backend.retrosynthesis.template import (
     generate_nodes_for_molecular_graph,
     run_retro_planner,
 )
-from charge_backend.moleculedb.purchasable import is_purchasable
+from charge_backend.moleculedb.purchasable import (
+    is_purchasable,
+    purchasable_summary,
+)
 from charge_backend.retrosynthesis.mapping import build_mapped_reaction_dict_or_none
 from charge_backend.retrosynthesis.database import find_exact_reactions
 
@@ -229,10 +232,7 @@ async def ai_based_retrosynthesis(
     for smiles in result.reactants_smiles_list:
         node_id_str = context.new_node_id()
         mol_sources = is_purchasable(smiles)
-        if mol_sources:
-            purchasable_str = f"Yes (via {', '.join(mol_sources)})"
-        else:
-            purchasable_str = "No"
+        purchasable_str = purchasable_summary(mol_sources)
         node = Node(
             node_id_str,
             smiles,

--- a/charge_backend/retrosynthesis/alternatives.py
+++ b/charge_backend/retrosynthesis/alternatives.py
@@ -7,7 +7,10 @@ from charge_backend.backend_helper_funcs import (
     Reaction,
 )
 from charge_backend.flask_experiment import GraphContext
-from charge_backend.moleculedb.purchasable import is_purchasable
+from charge_backend.moleculedb.purchasable import (
+    is_purchasable,
+    purchasable_summary,
+)
 from charge_backend.retrosynthesis.mapping import build_mapped_reaction_dict_or_none
 
 
@@ -89,10 +92,7 @@ async def set_reaction_alternative(
                 parent_node = step_nodes[i - 1][parent]
 
                 mol_sources = is_purchasable(smiles)
-                if mol_sources:
-                    purchasable_str = f"Yes (via {', '.join(mol_sources)})"
-                else:
-                    purchasable_str = "No"
+                purchasable_str = purchasable_summary(mol_sources)
                 child_node = Node(
                     id=context.new_node_id(),
                     smiles=smiles,

--- a/charge_backend/retrosynthesis/database.py
+++ b/charge_backend/retrosynthesis/database.py
@@ -15,7 +15,10 @@ from charge_backend.backend_helper_funcs import (
 from charge_backend.moleculedb.molecule_naming import (
     smiles_to_html,
 )
-from charge_backend.moleculedb.purchasable import is_purchasable
+from charge_backend.moleculedb.purchasable import (
+    is_purchasable,
+    purchasable_summary,
+)
 from charge_backend.moleculedb.dynamic_import import import_from_path
 from charge_backend.moleculedb.reactiondb_query import ReactionDatabaseReader
 
@@ -290,10 +293,7 @@ async def find_exact_reactions(
                 reactant_smiles, reactant_labels, reactant_roles
             ):
                 mol_sources = is_purchasable(smiles)
-                if mol_sources:
-                    purchasable_str = f"Yes (via {', '.join(mol_sources)})"
-                else:
-                    purchasable_str = "No"
+                purchasable_str = purchasable_summary(mol_sources)
                 node = Node(
                     id=context.new_node_id(),
                     smiles=smiles,

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -1,0 +1,131 @@
+from fastapi import WebSocket
+
+from rdkit import Chem
+
+from lc_conductor.callback_logger import CallbackLogger
+
+from charge_backend.backend_helper_funcs import (
+    Node,
+    Reaction,
+    FlaskRunSettings,
+)
+from charge_backend.flask_experiment import GraphContext
+from charge_backend.moleculedb.molecule_naming import smiles_to_html
+from charge_backend.moleculedb.purchasable import is_purchasable
+from charge_backend.retrosynthesis.mapping import build_mapped_reaction_dict_or_none
+from charge_backend.rdkit_mol_differ import parse_reaction_smiles
+
+
+def _purchasable_str(mol_sources: list[str]) -> str:
+    if mol_sources:
+        return f"Yes (via {', '.join(mol_sources)})"
+    return "No"
+
+
+def _select_root_product(products: list[Chem.Mol]) -> Chem.Mol:
+    """Pick the product with the most heavy atoms as the target molecule.
+
+    Additional products are treated as byproducts and ignored.
+    """
+    return max(products, key=lambda m: m.GetNumHeavyAtoms())
+
+
+async def reaction_smiles_retrosynthesis(
+    reaction_smiles: str,
+    context: GraphContext,
+    websocket: WebSocket,
+    run_settings: FlaskRunSettings,
+) -> None:
+    """Build a one-step partial retrosynthesis graph from a reaction SMILES.
+
+    The product (largest, by heavy-atom count) becomes the root target node and
+    each reactant becomes a level-1 child, as if the user had performed a single
+    retrosynthesis step. No route search is performed -- the user supplies the
+    reaction.
+    """
+    clogger = CallbackLogger(websocket, source="reaction_smiles_retrosynthesis")
+    await clogger.info(f"Building partial graph from reaction: `{reaction_smiles}`.")
+
+    context.reset()
+
+    # Parse the reaction SMILES (agents, if any, are ignored).
+    try:
+        reactant_mols, product_mols = parse_reaction_smiles(reaction_smiles)
+    except ValueError as e:
+        await clogger.error(f"Could not parse reaction SMILES: {e}")
+        await websocket.send_json({"type": "complete"})
+        return
+
+    if not reactant_mols or not product_mols:
+        await clogger.error(
+            "Reaction SMILES must contain at least one reactant and one product "
+            "(format: `reactant1.reactant2>>product`)."
+        )
+        await websocket.send_json({"type": "complete"})
+        return
+
+    product_mol = _select_root_product(product_mols)
+    product_smiles = Chem.MolToSmiles(product_mol)
+    reactant_smiles = [Chem.MolToSmiles(m) for m in reactant_mols]
+
+    if len(product_mols) > 1:
+        await clogger.info(
+            f"Multiple products found; using `{product_smiles}` as the target "
+            "and treating the rest as byproducts."
+        )
+
+    # Root node = product.
+    mol_sources = is_purchasable(product_smiles)
+    root = Node(
+        id="node_0",
+        smiles=product_smiles,
+        label=smiles_to_html(product_smiles, run_settings.molecule_name_format),
+        hoverInfo=f"""# Root molecule
+**SMILES:** {product_smiles}
+
+**Purchasable**? {_purchasable_str(mol_sources)}""",
+        level=0,
+        parentId=None,
+        purchasable=(len(mol_sources) > 0),
+        highlight="yellow",
+        x=100,
+        y=100,
+    )
+    await context.add_node(root, websocket=websocket)
+
+    # Child nodes = reactants.
+    for smiles in reactant_smiles:
+        child_sources = is_purchasable(smiles)
+        node = Node(
+            id=context.new_node_id(),
+            smiles=smiles,
+            label=smiles_to_html(smiles, run_settings.molecule_name_format),
+            hoverInfo=f"""# Reactant
+  * SMILES: {smiles}
+  * Purchasable? {_purchasable_str(child_sources)}
+""",
+            level=1,
+            parentId=root.id,
+            purchasable=(len(child_sources) > 0),
+        )
+        await context.add_node(node, websocket)
+
+    # Attach the user-supplied reaction to the root, with a mapped reaction so
+    # hover-highlighting works. templatesSearched=False so the user can still
+    # expand children later with templates/AI.
+    root.reaction = Reaction(
+        "user_rxn",
+        f"User-provided reaction\n\n**Reaction SMILES:** `{reaction_smiles}`",
+        highlight="yellow",
+        label="User reaction",
+        templatesSearched=False,
+    )
+    root.reaction.mappedReaction = build_mapped_reaction_dict_or_none(
+        reactants=reactant_smiles,
+        products=[product_smiles],
+        log_msg="Failed to build rdkitjs mapped reaction for user reaction root_id={node_id} smiles={smiles}",
+        node_id=root.id,
+        smiles=root.smiles,
+    )
+    await context.update_node(root, websocket)
+    await websocket.send_json({"type": "complete"})

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -52,9 +52,13 @@ async def reaction_smiles_retrosynthesis(
 
     context.reset()
 
-    # Parse the reaction SMILES (agents: e.g. solvent, catalyst, if any, are ignored).
+    # Parse the reaction SMILES. Agents (e.g. solvent, catalyst) are surfaced as
+    # child nodes labeled "(Agent)", mirroring the exact-reaction database path
+    # which appends each component's role to its label.
     try:
-        reactant_mols, product_mols = parse_reaction_smiles(reaction_smiles)
+        reactant_mols, agent_mols, product_mols = parse_reaction_smiles(
+            reaction_smiles, include_agents=True
+        )
     except ValueError as e:
         await clogger.error(f"Could not parse reaction SMILES: {e}")
         await websocket.send_json({"type": "complete"})
@@ -72,6 +76,7 @@ async def reaction_smiles_retrosynthesis(
     product_smiles = Chem.MolToSmiles(product_mol)
     all_product_smiles = [Chem.MolToSmiles(m) for m in product_mols]
     reactant_smiles = [Chem.MolToSmiles(m) for m in reactant_mols]
+    agent_smiles = [Chem.MolToSmiles(m) for m in agent_mols]
 
     if len(product_mols) > 1:
         await clogger.info(
@@ -98,14 +103,17 @@ async def reaction_smiles_retrosynthesis(
     )
     await context.add_node(root, websocket=websocket)
 
-    # Child nodes = reactants.
-    for smiles in reactant_smiles:
+    # Child nodes = reactants, then agents (labeled with their role).
+    async def _add_child(smiles: str, role: str) -> None:
         child_sources = is_purchasable(smiles)
+        label = smiles_to_html(smiles, run_settings.molecule_name_format)
+        if role != "Reactant":
+            label = f"{label} ({role})"
         node = Node(
             id=context.new_node_id(),
             smiles=smiles,
-            label=smiles_to_html(smiles, run_settings.molecule_name_format),
-            hoverInfo=f"""# Reactant
+            label=label,
+            hoverInfo=f"""# {role}
   * SMILES: {smiles}
   * Purchasable? {purchasable_summary(child_sources)}
 """,
@@ -114,6 +122,11 @@ async def reaction_smiles_retrosynthesis(
             purchasable=(len(child_sources) > 0),
         )
         await context.add_node(node, websocket)
+
+    for smiles in reactant_smiles:
+        await _add_child(smiles, "Reactant")
+    for smiles in agent_smiles:
+        await _add_child(smiles, "Agent")
 
     # Attach the user-supplied reaction to the root, with a mapped reaction so
     # hover-highlighting works. templatesSearched=False so the user can still
@@ -126,7 +139,7 @@ async def reaction_smiles_retrosynthesis(
         templatesSearched=False,
     )
     root.reaction.mappedReaction = build_mapped_reaction_dict_or_none(
-        reactants=reactant_smiles,
+        reactants=reactant_smiles + agent_smiles,
         products=[product_smiles],
         log_msg="Failed to build rdkitjs mapped reaction for user reaction root_id={node_id} smiles={smiles}",
         node_id=root.id,

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -39,6 +39,7 @@ async def reaction_smiles_retrosynthesis(
     context: GraphContext,
     websocket: WebSocket,
     run_settings: FlaskRunSettings,
+    send_complete: bool = True,
 ) -> None:
     """Build a one-step partial retrosynthesis graph from a reaction SMILES.
 
@@ -46,6 +47,10 @@ async def reaction_smiles_retrosynthesis(
     each reactant becomes a level-1 child, as if the user had performed a single
     retrosynthesis step. No route search is performed -- the user supplies the
     reaction.
+
+    :param send_complete: If True (default), send a ``{"type": "complete"}``
+        message when finished. Set False when a caller (e.g. the custom-problem
+        flow) will run further work and send ``complete`` itself.
     """
     clogger = CallbackLogger(websocket, source="reaction_smiles_retrosynthesis")
     await clogger.info(f"Building partial graph from reaction: `{reaction_smiles}`.")
@@ -61,7 +66,8 @@ async def reaction_smiles_retrosynthesis(
         )
     except ValueError as e:
         await clogger.error(f"Could not parse reaction SMILES: {e}")
-        await websocket.send_json({"type": "complete"})
+        if send_complete:
+            await websocket.send_json({"type": "complete"})
         return
 
     if not reactant_mols or not product_mols:
@@ -69,7 +75,8 @@ async def reaction_smiles_retrosynthesis(
             "Reaction SMILES must contain at least one reactant and one product "
             "(format: `reactant1.reactant2>>product`)."
         )
-        await websocket.send_json({"type": "complete"})
+        if send_complete:
+            await websocket.send_json({"type": "complete"})
         return
 
     product_mol = _select_root_product(product_mols)
@@ -146,4 +153,5 @@ async def reaction_smiles_retrosynthesis(
         smiles=root.smiles,
     )
     await context.update_node(root, websocket)
-    await websocket.send_json({"type": "complete"})
+    if send_complete:
+        await websocket.send_json({"type": "complete"})

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -1,3 +1,10 @@
+################################################################################
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC..
+## See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 from fastapi import WebSocket
 
 from rdkit import Chem
@@ -48,7 +55,7 @@ async def reaction_smiles_retrosynthesis(
 
     context.reset()
 
-    # Parse the reaction SMILES (agents, if any, are ignored).
+    # Parse the reaction SMILES (agents: e.g. solvent, catalyst, if any, are ignored).
     try:
         reactant_mols, product_mols = parse_reaction_smiles(reaction_smiles)
     except ValueError as e:
@@ -117,7 +124,7 @@ async def reaction_smiles_retrosynthesis(
         "user_rxn",
         f"User-provided reaction\n\n**Reaction SMILES:** `{reaction_smiles}`",
         highlight="yellow",
-        label="User reaction",
+        label="User",
         templatesSearched=False,
     )
     root.reaction.mappedReaction = build_mapped_reaction_dict_or_none(

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -85,8 +85,9 @@ async def reaction_smiles_retrosynthesis(
     reagent_smiles = [Chem.MolToSmiles(m) for m in reagent_mols]
 
     if len(product_mols) > 1:
+        products_smiles = reaction_smiles.split(">").pop().split(".")
         await clogger.info(
-            f"Multiple products found in {reaction_smiles.split('>').pop()}; using `{product_smiles}` as the target "
+            f"Multiple products found in {products_smiles}; using `{product_smiles}` as the target "
             "and treating the rest as byproducts."
         )
 

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -52,12 +52,12 @@ async def reaction_smiles_retrosynthesis(
 
     context.reset()
 
-    # Parse the reaction SMILES. Agents (e.g. solvent, catalyst) are surfaced as
-    # child nodes labeled "(Agent)", mirroring the exact-reaction database path
+    # Parse the reaction SMILES. Reagents (e.g. solvent, catalyst) are surfaced as
+    # child nodes labeled "(Reagent)", mirroring the exact-reaction database path
     # which appends each component's role to its label.
     try:
-        reactant_mols, agent_mols, product_mols = parse_reaction_smiles(
-            reaction_smiles, include_agents=True
+        reactant_mols, reagent_mols, product_mols = parse_reaction_smiles(
+            reaction_smiles, include_reagents=True
         )
     except ValueError as e:
         await clogger.error(f"Could not parse reaction SMILES: {e}")
@@ -76,7 +76,7 @@ async def reaction_smiles_retrosynthesis(
     product_smiles = Chem.MolToSmiles(product_mol)
     all_product_smiles = [Chem.MolToSmiles(m) for m in product_mols]
     reactant_smiles = [Chem.MolToSmiles(m) for m in reactant_mols]
-    agent_smiles = [Chem.MolToSmiles(m) for m in agent_mols]
+    reagent_smiles = [Chem.MolToSmiles(m) for m in reagent_mols]
 
     if len(product_mols) > 1:
         await clogger.info(
@@ -103,7 +103,7 @@ async def reaction_smiles_retrosynthesis(
     )
     await context.add_node(root, websocket=websocket)
 
-    # Child nodes = reactants, then agents (labeled with their role).
+    # Child nodes = reactants, then reagents (labeled with their role).
     async def _add_child(smiles: str, role: str) -> None:
         child_sources = is_purchasable(smiles)
         label = smiles_to_html(smiles, run_settings.molecule_name_format)
@@ -125,8 +125,8 @@ async def reaction_smiles_retrosynthesis(
 
     for smiles in reactant_smiles:
         await _add_child(smiles, "Reactant")
-    for smiles in agent_smiles:
-        await _add_child(smiles, "Agent")
+    for smiles in reagent_smiles:
+        await _add_child(smiles, "Reagent")
 
     # Attach the user-supplied reaction to the root, with a mapped reaction so
     # hover-highlighting works. templatesSearched=False so the user can still
@@ -139,7 +139,7 @@ async def reaction_smiles_retrosynthesis(
         templatesSearched=False,
     )
     root.reaction.mappedReaction = build_mapped_reaction_dict_or_none(
-        reactants=reactant_smiles + agent_smiles,
+        reactants=reactant_smiles + reagent_smiles,
         products=[product_smiles],
         log_msg="Failed to build rdkitjs mapped reaction for user reaction root_id={node_id} smiles={smiles}",
         node_id=root.id,

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -23,15 +23,45 @@ from charge_backend.moleculedb.purchasable import (
     purchasable_summary,
 )
 from charge_backend.retrosynthesis.mapping import build_mapped_reaction_dict_or_none
-from charge_backend.rdkit_mol_differ import parse_reaction_smiles
 
 
-def _select_root_product(products: list[Chem.Mol]) -> Chem.Mol:
-    """Pick the product with the most heavy atoms as the target molecule.
+def _split_reaction_smiles(
+    reaction_smiles: str,
+) -> tuple[list[str], list[str], list[str]]:
+    """Split a reaction SMILES into (reactants, reagents, products).
 
-    Additional products are treated as byproducts and ignored.
+    A reaction SMILES has exactly two '>' separators
+    (``reactants>reagents>products``); the reagents field may be empty. Each
+    field is a '.'-separated list of molecule SMILES; empty components are
+    dropped.
     """
-    return max(products, key=lambda m: m.GetNumHeavyAtoms())
+    parts = reaction_smiles.split(">")
+    if len(parts) != 3:
+        raise ValueError(
+            "Invalid reaction SMILES (expected reactants>reagents>products): "
+            f"{reaction_smiles!r}"
+        )
+    reactants = [s for s in parts[0].split(".") if s]
+    reagents = [s for s in parts[1].split(".") if s]
+    products = [s for s in parts[2].split(".") if s]
+    return reactants, reagents, products
+
+
+def _select_root_product(product_smiles: list[str]) -> int:
+    """Return the index of the product with the most heavy atoms.
+
+    Additional products are treated as byproducts and ignored. Products that
+    fail to parse count as zero heavy atoms.
+    """
+
+    def heavy_atom_count(smiles: str) -> int:
+        mol = Chem.MolFromSmiles(smiles)
+        return mol.GetNumHeavyAtoms() if mol is not None else 0
+
+    return max(
+        range(len(product_smiles)),
+        key=lambda i: heavy_atom_count(product_smiles[i]),
+    )
 
 
 async def reaction_smiles_retrosynthesis(
@@ -61,8 +91,8 @@ async def reaction_smiles_retrosynthesis(
     # child nodes labeled "(Reagent)", mirroring the exact-reaction database path
     # which appends each component's role to its label.
     try:
-        reactant_mols, reagent_mols, product_mols = parse_reaction_smiles(
-            reaction_smiles, include_reagents=True
+        reactant_smiles, reagent_smiles, product_smiles = _split_reaction_smiles(
+            reaction_smiles
         )
     except ValueError as e:
         await clogger.error(f"Could not parse reaction SMILES: {e}")
@@ -70,7 +100,7 @@ async def reaction_smiles_retrosynthesis(
             await websocket.send_json({"type": "complete"})
         return
 
-    if not reactant_mols or not product_mols:
+    if not reactant_smiles or not product_smiles:
         await clogger.error(
             "Reaction SMILES must contain at least one reactant and one product "
             "(format: `reactant1.reactant2>>product`)."
@@ -79,26 +109,23 @@ async def reaction_smiles_retrosynthesis(
             await websocket.send_json({"type": "complete"})
         return
 
-    product_mol = _select_root_product(product_mols)
-    product_smiles = Chem.MolToSmiles(product_mol)
-    reactant_smiles = [Chem.MolToSmiles(m) for m in reactant_mols]
-    reagent_smiles = [Chem.MolToSmiles(m) for m in reagent_mols]
+    root_index = _select_root_product(product_smiles)
+    product = product_smiles[root_index]
 
-    if len(product_mols) > 1:
-        products_smiles = reaction_smiles.split(">").pop().split(".")
+    if len(product_smiles) > 1:
         await clogger.info(
-            f"Multiple products found in {products_smiles}; using `{product_smiles}` as the target "
-            "and treating the rest as byproducts."
+            f"Multiple products found in {product_smiles}; using `{product}` as the "
+            "target and treating the rest as byproducts."
         )
 
     # Root node = product.
-    mol_sources = is_purchasable(product_smiles)
+    mol_sources = is_purchasable(product)
     root = Node(
         id="node_0",
-        smiles=product_smiles,
-        label=smiles_to_html(product_smiles, run_settings.molecule_name_format),
+        smiles=product,
+        label=smiles_to_html(product, run_settings.molecule_name_format),
         hoverInfo=f"""# Root molecule
-**SMILES:** {product_smiles}
+**SMILES:** {product}
 
 **Purchasable**? {purchasable_summary(mol_sources)}""",
         level=0,
@@ -147,7 +174,7 @@ async def reaction_smiles_retrosynthesis(
     )
     root.reaction.mappedReaction = build_mapped_reaction_dict_or_none(
         reactants=reactant_smiles + reagent_smiles,
-        products=[product_smiles],
+        products=[product],
         log_msg="Failed to build rdkitjs mapped reaction for user reaction root_id={node_id} smiles={smiles}",
         node_id=root.id,
         smiles=root.smiles,

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -18,15 +18,12 @@ from charge_backend.backend_helper_funcs import (
 )
 from charge_backend.flask_experiment import GraphContext
 from charge_backend.moleculedb.molecule_naming import smiles_to_html
-from charge_backend.moleculedb.purchasable import is_purchasable
+from charge_backend.moleculedb.purchasable import (
+    is_purchasable,
+    purchasable_summary,
+)
 from charge_backend.retrosynthesis.mapping import build_mapped_reaction_dict_or_none
 from charge_backend.rdkit_mol_differ import parse_reaction_smiles
-
-
-def _purchasable_str(mol_sources: list[str]) -> str:
-    if mol_sources:
-        return f"Yes (via {', '.join(mol_sources)})"
-    return "No"
 
 
 def _select_root_product(products: list[Chem.Mol]) -> Chem.Mol:
@@ -91,7 +88,7 @@ async def reaction_smiles_retrosynthesis(
         hoverInfo=f"""# Root molecule
 **SMILES:** {product_smiles}
 
-**Purchasable**? {_purchasable_str(mol_sources)}""",
+**Purchasable**? {purchasable_summary(mol_sources)}""",
         level=0,
         parentId=None,
         purchasable=(len(mol_sources) > 0),
@@ -110,7 +107,7 @@ async def reaction_smiles_retrosynthesis(
             label=smiles_to_html(smiles, run_settings.molecule_name_format),
             hoverInfo=f"""# Reactant
   * SMILES: {smiles}
-  * Purchasable? {_purchasable_str(child_sources)}
+  * Purchasable? {purchasable_summary(child_sources)}
 """,
             level=1,
             parentId=root.id,

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -73,11 +73,12 @@ async def reaction_smiles_retrosynthesis(
 
     product_mol = _select_root_product(product_mols)
     product_smiles = Chem.MolToSmiles(product_mol)
+    all_product_smiles = [Chem.MolToSmiles(m) for m in product_mols]
     reactant_smiles = [Chem.MolToSmiles(m) for m in reactant_mols]
 
     if len(product_mols) > 1:
         await clogger.info(
-            f"Multiple products found; using `{product_smiles}` as the target "
+            f"Multiple products found in {all_product_smiles}; using `{product_smiles}` as the target "
             "and treating the rest as byproducts."
         )
 

--- a/charge_backend/retrosynthesis/reaction_smiles.py
+++ b/charge_backend/retrosynthesis/reaction_smiles.py
@@ -81,13 +81,12 @@ async def reaction_smiles_retrosynthesis(
 
     product_mol = _select_root_product(product_mols)
     product_smiles = Chem.MolToSmiles(product_mol)
-    all_product_smiles = [Chem.MolToSmiles(m) for m in product_mols]
     reactant_smiles = [Chem.MolToSmiles(m) for m in reactant_mols]
     reagent_smiles = [Chem.MolToSmiles(m) for m in reagent_mols]
 
     if len(product_mols) > 1:
         await clogger.info(
-            f"Multiple products found in {all_product_smiles}; using `{product_smiles}` as the target "
+            f"Multiple products found in {reaction_smiles.split('>').pop()}; using `{product_smiles}` as the target "
             "and treating the rest as byproducts."
         )
 

--- a/charge_backend/retrosynthesis/template.py
+++ b/charge_backend/retrosynthesis/template.py
@@ -17,7 +17,10 @@ from charge_backend.moleculedb.molecule_naming import (
     smiles_to_html,
     MolNameFormat,
 )
-from charge_backend.moleculedb.purchasable import is_purchasable
+from charge_backend.moleculedb.purchasable import (
+    is_purchasable,
+    purchasable_summary,
+)
 from charge_backend.retrosynthesis.database import find_exact_reactions
 from charge_backend.retrosynthesis.mapping import build_mapped_reaction_dict_or_none
 
@@ -75,10 +78,7 @@ async def generate_nodes_for_molecular_graph(
         node_id_str = retro_synth_context.new_node_id()
         hover_info = f"# Molecule\n\n**SMILES:** {smiles}\n\n"
         mol_sources = is_purchasable(smiles)
-        if mol_sources:
-            purchasable_str = f"Yes (via {', '.join(mol_sources)})"
-        else:
-            purchasable_str = "No"
+        purchasable_str = purchasable_summary(mol_sources)
         hover_info += f"**Purchasable**? {purchasable_str}\n"
 
         node = Node(
@@ -277,10 +277,7 @@ async def template_based_retrosynthesis(
     # Generate root node
     context.reset()  # Clear context
     mol_sources = is_purchasable(start_smiles)
-    if mol_sources:
-        purchasable_str = f"Yes (via {', '.join(mol_sources)})"
-    else:
-        purchasable_str = "No"
+    purchasable_str = purchasable_summary(mol_sources)
     root = Node(
         id="node_0",
         smiles=start_smiles,

--- a/charge_backend/tests/test_custom_reaction_integration.py
+++ b/charge_backend/tests/test_custom_reaction_integration.py
@@ -1,0 +1,117 @@
+###############################################################################
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC.
+## See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+"""Integration test driving the real FlaskActionManager._handle_custom_problem.
+
+Guards against regressions in the message sequence streamed to the browser for
+a custom problem whose input is a reaction SMILES -- specifically that BOTH
+node and edge messages are emitted so the frontend can wire the graph.
+"""
+
+import argparse
+import asyncio
+
+from charge_backend.backend_manager import FlaskActionManager
+from charge_backend import flask_experiment as fe
+
+
+class CollectingWebSocket:
+    """Fake websocket that records every message sent."""
+
+    headers: dict = {}
+
+    def __init__(self):
+        self.messages = []
+
+    async def send_json(self, payload):
+        self.messages.append(payload)
+
+    async def send_text(self, payload):
+        self.messages.append(payload)
+
+
+class FakeAgent:
+    def __init__(self, result):
+        self._result = result
+
+    async def run(self):
+        return self._result
+
+
+def _make_manager():
+    websocket = CollectingWebSocket()
+    manager = FlaskActionManager(
+        websocket=websocket,
+        args=argparse.Namespace(
+            backend="openai",
+            model="gpt-4o-mini",
+            config_file=None,
+            json_file=None,
+            max_retries=1,
+        ),
+        username="test-user",
+    )
+    return manager, websocket
+
+
+def test_custom_reaction_smiles_streams_nodes_and_edges(monkeypatch):
+    manager, websocket = _make_manager()
+
+    # Stub the agent runtime so no real backend is needed. The agent echoes the
+    # product/reactant SMILES, which must NOT be re-added as nodes.
+    agent_reply = 'Analysis: product {"smiles": "C=CCI"} from {"smiles": "C=CCBr"}.'
+    monkeypatch.setattr(
+        fe.FlaskExperiment,
+        "create_agent_with_experiment_state",
+        lambda self, *a, **k: FakeAgent(agent_reply),
+    )
+    monkeypatch.setattr(
+        fe.FlaskExperiment, "add_to_context", lambda self, *a, **k: None
+    )
+
+    # selected_tool_runtime() needs a wrapped websocket for bearer-token
+    # extraction, which is irrelevant here (FakeAgent ignores the runtime).
+    from lc_conductor import ToolRuntime
+
+    monkeypatch.setattr(
+        manager,
+        "selected_tool_runtime",
+        lambda: ToolRuntime(bearer_token=None, tools=[]),
+    )
+
+    data = {
+        "smiles": "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]",
+        "problemType": "custom",
+        "systemPrompt": "sys",
+        "userPrompt": "analyze",
+    }
+
+    asyncio.run(manager._handle_custom_problem(data))
+
+    node_msgs = [m for m in websocket.messages if m.get("type") == "node"]
+    edge_msgs = [m for m in websocket.messages if m.get("type") == "edge"]
+
+    # Product root + 3 reactants + 1 reagent = 5 nodes.
+    node_ids = [m["node"]["id"] for m in node_msgs]
+    assert len(node_ids) == 5
+    assert len(node_ids) == len(set(node_ids)), "nodes must not be duplicated"
+
+    # Each non-root node must have a corresponding edge from the root, so the
+    # frontend can draw the reaction graph.
+    edge_pairs = {(m["edge"]["fromNode"], m["edge"]["toNode"]) for m in edge_msgs}
+    assert len(edge_msgs) == 4
+    for nid in node_ids:
+        if nid != "node_0":
+            assert ("node_0", nid) in edge_pairs
+
+    # Every edge endpoint must reference a streamed node (no dangling edges).
+    streamed = set(node_ids)
+    for frm, to in edge_pairs:
+        assert frm in streamed and to in streamed
+
+    # Exactly one terminal complete.
+    assert sum(1 for m in websocket.messages if m.get("type") == "complete") == 1

--- a/charge_backend/tests/test_custom_reaction_smiles.py
+++ b/charge_backend/tests/test_custom_reaction_smiles.py
@@ -1,0 +1,129 @@
+###############################################################################
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC.
+## See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+import asyncio
+
+from charge_backend.flask_experiment import FlaskExperiment
+from charge_backend.backend_helper_funcs import FlaskRunSettings
+from charge_backend.charge_backend_custom import run_custom_problem
+from charge_backend.retrosynthesis.reaction_smiles import (
+    reaction_smiles_retrosynthesis,
+)
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.messages = []
+
+    async def send_json(self, data):
+        self.messages.append(data)
+
+
+class FakeAgent:
+    """Returns a canned result that contains an extractable SMILES field."""
+
+    def __init__(self, result):
+        self._result = result
+
+    async def run(self):
+        return self._result
+
+
+class FakeToolRuntime:
+    def task_kwargs(self):
+        return {}
+
+
+class FakeExperiment(FlaskExperiment):
+    """FlaskExperiment with the agent runtime stubbed out."""
+
+    def __init__(self, agent_result):
+        super().__init__(task=None)
+        self._agent_result = agent_result
+
+    def create_agent_with_experiment_state(
+        self, task, *, agent_key=None, callback=None
+    ):
+        return FakeAgent(self._agent_result)
+
+    def add_to_context(self, agent, task, result):
+        pass
+
+
+def _run_custom(reaction_smiles, *, build_first, agent_result='{"smiles": "CCO"}'):
+    exp = FakeExperiment(agent_result)
+    ws = FakeWebSocket()
+    is_reaction = ">" in reaction_smiles
+
+    async def go():
+        if build_first and is_reaction:
+            await reaction_smiles_retrosynthesis(
+                reaction_smiles,
+                exp.graph_context,
+                ws,
+                FlaskRunSettings(),
+                send_complete=False,
+            )
+        await run_custom_problem(
+            reaction_smiles,
+            "system",
+            "user",
+            exp,
+            FakeToolRuntime(),
+            ws,
+            FlaskRunSettings(),
+            build_nodes_from_response=not (build_first and is_reaction),
+        )
+
+    asyncio.run(go())
+    return exp, ws
+
+
+def test_custom_reaction_smiles_builds_partial_graph_without_collision():
+    # The custom flow builds the reaction graph first, then runs the agent.
+    exp, ws = _run_custom(
+        "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]", build_first=True
+    )
+    g = exp.graph_context
+
+    # Reaction graph: product root + 3 reactants + 1 reagent = 5 nodes.
+    assert len(g.node_ids) == 5
+    root = g.node_ids["node_0"]
+    assert root.parentId is None
+    # The agent's "CCO" response node must NOT have been added (no collision).
+    assert all(n.smiles != "CCO" for n in g.node_ids.values())
+    # Exactly one "complete" (from the agent run, not the graph build).
+    assert ws.messages.count({"type": "complete"}) == 1
+
+
+def test_custom_reaction_smiles_not_duplicated_when_agent_echoes_molecules():
+    # Regression: the agent, given the full reaction SMILES, echoes the product
+    # and reactant SMILES back in its JSON response. The response-node builder
+    # must stay suppressed so those molecules are not added a SECOND time
+    # (which previously produced product+reactants duplicated, reagent single).
+    rxn = "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]"
+    agent_echo = (
+        'Product {"smiles": "C=CCI"} from reactants '
+        '{"smiles": "C=CCBr"}, {"smiles": "[Na+]"}, {"smiles": "[I-]"}'
+    )
+    exp, _ = _run_custom(rxn, build_first=True, agent_result=agent_echo)
+    g = exp.graph_context
+
+    # Still exactly the 5 reaction-graph nodes; no echoed duplicates.
+    assert len(g.node_ids) == 5
+    smiles_counts = {}
+    for n in g.node_ids.values():
+        smiles_counts[n.smiles] = smiles_counts.get(n.smiles, 0) + 1
+    assert all(count == 1 for count in smiles_counts.values())
+
+
+def test_custom_plain_smiles_still_builds_nodes_from_response():
+    # Non-reaction input: agent response nodes are still created as before.
+    exp, _ = _run_custom("c1ccccc1", build_first=True)
+    g = exp.graph_context
+    assert "node_0" in g.node_ids
+    assert g.node_ids["node_0"].smiles == "CCO"

--- a/charge_backend/tests/test_graph_context.py
+++ b/charge_backend/tests/test_graph_context.py
@@ -351,3 +351,24 @@ def test_graph_context_in_flask_experiment_load_state():
     assert not e.graph_context.is_empty()
     assert "f" not in e.graph_context.node_ids
     assert e.graph_context == g
+
+
+def test_flask_experiment_load_state_preserves_graph_context_identity():
+    # load_state must repopulate the EXISTING graph_context in place, not
+    # replace the object. Callers hand out a reference (get_retro_synth_context)
+    # and then mutate it; swapping the object would orphan those references and
+    # cause nodes to be written to a stale graph (seen as duplicated molecules).
+    e = FlaskExperiment(task=None)
+    handed_out = e.graph_context
+
+    g = GraphContext()
+    asyncio.run(g.add_node(make_node("a", 0)))
+    e.load_state({"graphContext": g.save_state()})
+
+    assert e.graph_context is handed_out
+    assert "a" in handed_out.node_ids
+
+    # The reset() path (old-style / empty) must also preserve identity.
+    e.load_state({"graphContext": GraphContext().save_state()})
+    assert e.graph_context is handed_out
+    assert handed_out.is_empty()

--- a/charge_backend/tests/test_rdkit_mol_differ.py
+++ b/charge_backend/tests/test_rdkit_mol_differ.py
@@ -1,6 +1,6 @@
 from rdkit import Chem
 
-import rdkit_mol_differ as md
+import charge_backend.rdkit_mol_differ as md
 
 
 def test_sn2_like_ether_formation_highlights_leaving_group_and_new_bond_site():

--- a/charge_backend/tests/test_reaction_smiles_retro.py
+++ b/charge_backend/tests/test_reaction_smiles_retro.py
@@ -1,0 +1,87 @@
+###############################################################################
+## Copyright 2025-2026 Lawrence Livermore National Security, LLC.
+## See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+import asyncio
+
+from rdkit import Chem
+
+from charge_backend.flask_experiment import GraphContext
+from charge_backend.backend_helper_funcs import FlaskRunSettings
+from charge_backend.retrosynthesis.reaction_smiles import (
+    reaction_smiles_retrosynthesis,
+)
+
+
+class FakeWebSocket:
+    """Records send_json calls so tests can inspect what was transmitted."""
+
+    def __init__(self):
+        self.messages = []
+
+    async def send_json(self, data):
+        self.messages.append(data)
+
+
+def _run(reaction_smiles: str):
+    g = GraphContext()
+    ws = FakeWebSocket()
+    asyncio.run(
+        reaction_smiles_retrosynthesis(reaction_smiles, g, ws, FlaskRunSettings())
+    )
+    return g, ws
+
+
+def _canon(smiles: str) -> str:
+    return Chem.MolToSmiles(Chem.MolFromSmiles(smiles))
+
+
+def test_single_product_builds_partial_graph():
+    g, ws = _run("BrC1=CC=NC=C1.C=CB(O)O>>C=Cc2ccncc2")
+
+    # One root (product) + two children (reactants)
+    assert len(g.node_ids) == 3
+    root = g.node_ids["node_0"]
+    assert root.level == 0
+    assert root.parentId is None
+    assert root.smiles == _canon("C=Cc2ccncc2")
+
+    children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
+    assert len(children) == 2
+    assert all(c.level == 1 for c in children)
+    child_smiles = {c.smiles for c in children}
+    assert child_smiles == {_canon("BrC1=CC=NC=C1"), _canon("C=CB(O)O")}
+
+    # Root has a reaction with a mapped reaction for hover-highlighting
+    assert root.reaction is not None
+    assert root.reaction.id == "user_rxn"
+    assert root.reaction.mappedReaction is not None
+
+    assert ws.messages[-1] == {"type": "complete"}
+
+
+def test_multi_product_roots_on_largest():
+    # Larger product is the pyridine ring system, not the methane byproduct.
+    g, _ = _run("BrC1=CC=NC=C1.C=CB(O)O>>C=Cc2ccncc2.C")
+    root = g.node_ids["node_0"]
+    assert root.smiles == _canon("C=Cc2ccncc2")
+    # Byproduct "C" is dropped; only the two reactants are children.
+    assert len(g.node_ids) == 3
+
+
+def test_agents_are_ignored():
+    # reactants>agent>product form
+    g, _ = _run("BrC1=CC=NC=C1.C=CB(O)O>[Pd]>C=Cc2ccncc2")
+    root = g.node_ids["node_0"]
+    assert root.smiles == _canon("C=Cc2ccncc2")
+    children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
+    assert len(children) == 2
+
+
+def test_invalid_reaction_smiles_does_not_crash():
+    g, ws = _run("this is not a reaction")
+    assert len(g.node_ids) == 0
+    assert ws.messages[-1] == {"type": "complete"}

--- a/charge_backend/tests/test_reaction_smiles_retro.py
+++ b/charge_backend/tests/test_reaction_smiles_retro.py
@@ -72,13 +72,13 @@ def test_multi_product_roots_on_largest():
     assert len(g.node_ids) == 3
 
 
-def test_agents_appear_as_labeled_children():
-    # reactants>agent>product form: the Pd agent becomes a child labeled "(Agent)".
+def test_reagents_appear_as_labeled_children():
+    # reactants>reagent>product form: the Pd reagent becomes a child labeled "(Reagent)".
     g, _ = _run("BrC1=CC=NC=C1.C=CB(O)O>[Pd]>C=Cc2ccncc2")
     root = g.node_ids["node_0"]
     assert root.smiles == _canon("C=Cc2ccncc2")
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
-    # Two reactants + one agent
+    # Two reactants + one reagent
     assert len(children) == 3
     child_smiles = {c.smiles for c in children}
     assert child_smiles == {
@@ -86,10 +86,10 @@ def test_agents_appear_as_labeled_children():
         _canon("C=CB(O)O"),
         _canon("[Pd]"),
     }
-    # The agent child carries a "(Agent)" role in its label.
-    agent_child = next(c for c in children if c.smiles == _canon("[Pd]"))
-    assert "(Agent)" in agent_child.label
-    assert "# Agent" in agent_child.hoverInfo
+    # The reagent child carries a "(Reagent)" role in its label.
+    reagent_child = next(c for c in children if c.smiles == _canon("[Pd]"))
+    assert "(Reagent)" in reagent_child.label
+    assert "# Reagent" in reagent_child.hoverInfo
 
 
 def test_invalid_reaction_smiles_does_not_crash():
@@ -98,11 +98,11 @@ def test_invalid_reaction_smiles_does_not_crash():
     assert ws.messages[-1] == {"type": "complete"}
 
 
-# --- Daylight reaction SMILES spec examples (reactant '>' agent '>' product) ---
+# --- Daylight reaction SMILES spec examples (reactant '>' reagent '>' product) ---
 
 
-def test_spec_example_no_agent():
-    # "C=CCBr>>C=CCI" -- allyl bromide to allyl iodide, no agent.
+def test_spec_example_no_reagent():
+    # "C=CCBr>>C=CCI" -- allyl bromide to allyl iodide, no reagent.
     g, ws = _run("C=CCBr>>C=CCI")
 
     assert len(g.node_ids) == 2
@@ -130,16 +130,16 @@ def test_spec_example_canonicalized_with_ions():
     assert child_smiles == {_canon("[I-]"), _canon("[Na+]"), _canon("C=CCBr")}
 
 
-def test_spec_example_with_agent():
-    # "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]" -- acetone is an agent
-    # (solvent). It is surfaced as a child node labeled "(Agent)".
+def test_spec_example_with_reagent():
+    # "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]" -- acetone is a reagent
+    # (solvent). It is surfaced as a child node labeled "(Reagent)".
     g, _ = _run("C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]")
 
     root = g.node_ids["node_0"]
     assert root.smiles == _canon("C=CCI")
 
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
-    # Three reactants + the acetone agent.
+    # Three reactants + the acetone reagent.
     assert len(children) == 4
     child_smiles = {c.smiles for c in children}
     assert child_smiles == {
@@ -148,6 +148,6 @@ def test_spec_example_with_agent():
         _canon("[I-]"),
         _canon("CC(=O)C"),
     }
-    # The acetone agent appears with a "(Agent)" role label.
-    agent_child = next(c for c in children if c.smiles == _canon("CC(=O)C"))
-    assert "(Agent)" in agent_child.label
+    # The acetone reagent appears with a "(Reagent)" role label.
+    reagent_child = next(c for c in children if c.smiles == _canon("CC(=O)C"))
+    assert "(Reagent)" in reagent_child.label

--- a/charge_backend/tests/test_reaction_smiles_retro.py
+++ b/charge_backend/tests/test_reaction_smiles_retro.py
@@ -72,13 +72,24 @@ def test_multi_product_roots_on_largest():
     assert len(g.node_ids) == 3
 
 
-def test_agents_are_ignored():
-    # reactants>agent>product form
+def test_agents_appear_as_labeled_children():
+    # reactants>agent>product form: the Pd agent becomes a child labeled "(Agent)".
     g, _ = _run("BrC1=CC=NC=C1.C=CB(O)O>[Pd]>C=Cc2ccncc2")
     root = g.node_ids["node_0"]
     assert root.smiles == _canon("C=Cc2ccncc2")
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
-    assert len(children) == 2
+    # Two reactants + one agent
+    assert len(children) == 3
+    child_smiles = {c.smiles for c in children}
+    assert child_smiles == {
+        _canon("BrC1=CC=NC=C1"),
+        _canon("C=CB(O)O"),
+        _canon("[Pd]"),
+    }
+    # The agent child carries a "(Agent)" role in its label.
+    agent_child = next(c for c in children if c.smiles == _canon("[Pd]"))
+    assert "(Agent)" in agent_child.label
+    assert "# Agent" in agent_child.hoverInfo
 
 
 def test_invalid_reaction_smiles_does_not_crash():
@@ -121,15 +132,22 @@ def test_spec_example_canonicalized_with_ions():
 
 def test_spec_example_with_agent():
     # "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]" -- acetone is an agent
-    # (solvent) and must be ignored; it is neither root nor a child.
+    # (solvent). It is surfaced as a child node labeled "(Agent)".
     g, _ = _run("C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]")
 
     root = g.node_ids["node_0"]
     assert root.smiles == _canon("C=CCI")
 
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
-    assert len(children) == 3
+    # Three reactants + the acetone agent.
+    assert len(children) == 4
     child_smiles = {c.smiles for c in children}
-    assert child_smiles == {_canon("C=CCBr"), _canon("[Na+]"), _canon("[I-]")}
-    # The acetone agent must not appear anywhere in the graph.
-    assert _canon("CC(=O)C") not in {n.smiles for n in g.node_ids.values()}
+    assert child_smiles == {
+        _canon("C=CCBr"),
+        _canon("[Na+]"),
+        _canon("[I-]"),
+        _canon("CC(=O)C"),
+    }
+    # The acetone agent appears with a "(Agent)" role label.
+    agent_child = next(c for c in children if c.smiles == _canon("CC(=O)C"))
+    assert "(Agent)" in agent_child.label

--- a/charge_backend/tests/test_reaction_smiles_retro.py
+++ b/charge_backend/tests/test_reaction_smiles_retro.py
@@ -85,3 +85,51 @@ def test_invalid_reaction_smiles_does_not_crash():
     g, ws = _run("this is not a reaction")
     assert len(g.node_ids) == 0
     assert ws.messages[-1] == {"type": "complete"}
+
+
+# --- Daylight reaction SMILES spec examples (reactant '>' agent '>' product) ---
+
+
+def test_spec_example_no_agent():
+    # "C=CCBr>>C=CCI" -- allyl bromide to allyl iodide, no agent.
+    g, ws = _run("C=CCBr>>C=CCI")
+
+    assert len(g.node_ids) == 2
+    root = g.node_ids["node_0"]
+    assert root.smiles == _canon("C=CCI")
+
+    children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
+    assert len(children) == 1
+    assert children[0].smiles == _canon("C=CCBr")
+    assert ws.messages[-1] == {"type": "complete"}
+
+
+def test_spec_example_canonicalized_with_ions():
+    # "[I-].[Na+].C=CCBr>>[Na+].[Br-].C=CCI" -- same reaction, fully specified.
+    # The organic product (most heavy atoms) is the root; the Na+/Br- salt
+    # byproducts are dropped. All three reactants become children.
+    g, _ = _run("[I-].[Na+].C=CCBr>>[Na+].[Br-].C=CCI")
+
+    root = g.node_ids["node_0"]
+    assert root.smiles == _canon("C=CCI")
+
+    children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
+    assert len(children) == 3
+    child_smiles = {c.smiles for c in children}
+    assert child_smiles == {_canon("[I-]"), _canon("[Na+]"), _canon("C=CCBr")}
+
+
+def test_spec_example_with_agent():
+    # "C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]" -- acetone is an agent
+    # (solvent) and must be ignored; it is neither root nor a child.
+    g, _ = _run("C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]")
+
+    root = g.node_ids["node_0"]
+    assert root.smiles == _canon("C=CCI")
+
+    children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
+    assert len(children) == 3
+    child_smiles = {c.smiles for c in children}
+    assert child_smiles == {_canon("C=CCBr"), _canon("[Na+]"), _canon("[I-]")}
+    # The acetone agent must not appear anywhere in the graph.
+    assert _canon("CC(=O)C") not in {n.smiles for n in g.node_ids.values()}

--- a/charge_backend/tests/test_reaction_smiles_retro.py
+++ b/charge_backend/tests/test_reaction_smiles_retro.py
@@ -7,8 +7,6 @@
 
 import asyncio
 
-from rdkit import Chem
-
 from charge_backend.flask_experiment import GraphContext
 from charge_backend.backend_helper_funcs import FlaskRunSettings
 from charge_backend.retrosynthesis.reaction_smiles import (
@@ -35,8 +33,8 @@ def _run(reaction_smiles: str):
     return g, ws
 
 
-def _canon(smiles: str) -> str:
-    return Chem.MolToSmiles(Chem.MolFromSmiles(smiles))
+# Node SMILES are the raw components from the input reaction SMILES (split on
+# '>' and '.'), so tests compare against the exact strings supplied.
 
 
 def test_single_product_builds_partial_graph():
@@ -47,13 +45,13 @@ def test_single_product_builds_partial_graph():
     root = g.node_ids["node_0"]
     assert root.level == 0
     assert root.parentId is None
-    assert root.smiles == _canon("C=Cc2ccncc2")
+    assert root.smiles == "C=Cc2ccncc2"
 
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
     assert len(children) == 2
     assert all(c.level == 1 for c in children)
     child_smiles = {c.smiles for c in children}
-    assert child_smiles == {_canon("BrC1=CC=NC=C1"), _canon("C=CB(O)O")}
+    assert child_smiles == {"BrC1=CC=NC=C1", "C=CB(O)O"}
 
     # Root has a reaction with a mapped reaction for hover-highlighting
     assert root.reaction is not None
@@ -67,7 +65,7 @@ def test_multi_product_roots_on_largest():
     # Larger product is the pyridine ring system, not the methane byproduct.
     g, _ = _run("BrC1=CC=NC=C1.C=CB(O)O>>C=Cc2ccncc2.C")
     root = g.node_ids["node_0"]
-    assert root.smiles == _canon("C=Cc2ccncc2")
+    assert root.smiles == "C=Cc2ccncc2"
     # Byproduct "C" is dropped; only the two reactants are children.
     assert len(g.node_ids) == 3
 
@@ -76,18 +74,14 @@ def test_reagents_appear_as_labeled_children():
     # reactants>reagent>product form: the Pd reagent becomes a child labeled "(Reagent)".
     g, _ = _run("BrC1=CC=NC=C1.C=CB(O)O>[Pd]>C=Cc2ccncc2")
     root = g.node_ids["node_0"]
-    assert root.smiles == _canon("C=Cc2ccncc2")
+    assert root.smiles == "C=Cc2ccncc2"
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
     # Two reactants + one reagent
     assert len(children) == 3
     child_smiles = {c.smiles for c in children}
-    assert child_smiles == {
-        _canon("BrC1=CC=NC=C1"),
-        _canon("C=CB(O)O"),
-        _canon("[Pd]"),
-    }
+    assert child_smiles == {"BrC1=CC=NC=C1", "C=CB(O)O", "[Pd]"}
     # The reagent child carries a "(Reagent)" role in its label.
-    reagent_child = next(c for c in children if c.smiles == _canon("[Pd]"))
+    reagent_child = next(c for c in children if c.smiles == "[Pd]")
     assert "(Reagent)" in reagent_child.label
     assert "# Reagent" in reagent_child.hoverInfo
 
@@ -107,27 +101,27 @@ def test_spec_example_no_reagent():
 
     assert len(g.node_ids) == 2
     root = g.node_ids["node_0"]
-    assert root.smiles == _canon("C=CCI")
+    assert root.smiles == "C=CCI"
 
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
     assert len(children) == 1
-    assert children[0].smiles == _canon("C=CCBr")
+    assert children[0].smiles == "C=CCBr"
     assert ws.messages[-1] == {"type": "complete"}
 
 
-def test_spec_example_canonicalized_with_ions():
+def test_spec_example_with_ions():
     # "[I-].[Na+].C=CCBr>>[Na+].[Br-].C=CCI" -- same reaction, fully specified.
     # The organic product (most heavy atoms) is the root; the Na+/Br- salt
     # byproducts are dropped. All three reactants become children.
     g, _ = _run("[I-].[Na+].C=CCBr>>[Na+].[Br-].C=CCI")
 
     root = g.node_ids["node_0"]
-    assert root.smiles == _canon("C=CCI")
+    assert root.smiles == "C=CCI"
 
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
     assert len(children) == 3
     child_smiles = {c.smiles for c in children}
-    assert child_smiles == {_canon("[I-]"), _canon("[Na+]"), _canon("C=CCBr")}
+    assert child_smiles == {"[I-]", "[Na+]", "C=CCBr"}
 
 
 def test_spec_example_with_reagent():
@@ -136,18 +130,13 @@ def test_spec_example_with_reagent():
     g, _ = _run("C=CCBr.[Na+].[I-]>CC(=O)C>C=CCI.[Na+].[Br-]")
 
     root = g.node_ids["node_0"]
-    assert root.smiles == _canon("C=CCI")
+    assert root.smiles == "C=CCI"
 
     children = [n for nid, n in g.node_ids.items() if g.parents.get(nid) == "node_0"]
     # Three reactants + the acetone reagent.
     assert len(children) == 4
     child_smiles = {c.smiles for c in children}
-    assert child_smiles == {
-        _canon("C=CCBr"),
-        _canon("[Na+]"),
-        _canon("[I-]"),
-        _canon("CC(=O)C"),
-    }
+    assert child_smiles == {"C=CCBr", "[Na+]", "[I-]", "CC(=O)C"}
     # The acetone reagent appears with a "(Reagent)" role label.
-    reagent_child = next(c for c in children if c.smiles == _canon("CC(=O)C"))
+    reagent_child = next(c for c in children if c.smiles == "CC(=O)C")
     assert "(Reagent)" in reagent_child.label

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -2425,7 +2425,7 @@ const ChemistryTool: React.FC = () => {
                     value={smiles}
                     onChange={(e) => setSmiles(e.target.value)}
                     disabled={isComputing}
-                    placeholder="Enter SMILES, or a reaction SMILES (A.B>>C)"
+                    placeholder="Enter SMILES or reaction SMILES"
                     className="form-input text-lg"
                   />
                 </div>

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -950,7 +950,7 @@ const ChemistryTool: React.FC = () => {
         propertyType === 'custom' ? customPropertyName : PROPERTY_NAMES[propertyType];
       experimentName = `Optimizing ${propertyName} for ${smiles}`;
     } else if (problemType === 'retrosynthesis') {
-      const target = smiles.includes('>>') ? smiles.split('>>').pop()?.trim() || smiles : smiles;
+      const target = smiles.includes('>') ? smiles.split('>').pop()?.trim() || smiles : smiles;
       experimentName = `Synthesizing ${target}`;
     }
 

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -950,7 +950,8 @@ const ChemistryTool: React.FC = () => {
         propertyType === 'custom' ? customPropertyName : PROPERTY_NAMES[propertyType];
       experimentName = `Optimizing ${propertyName} for ${smiles}`;
     } else if (problemType === 'retrosynthesis') {
-      experimentName = `Synthesizing ${smiles}`;
+      const target = smiles.includes('>>') ? smiles.split('>>').pop()?.trim() || smiles : smiles;
+      experimentName = `Synthesizing ${target}`;
     }
 
     // Check if we need to create project and/or experiment
@@ -2424,7 +2425,7 @@ const ChemistryTool: React.FC = () => {
                     value={smiles}
                     onChange={(e) => setSmiles(e.target.value)}
                     disabled={isComputing}
-                    placeholder="Enter SMILES notation"
+                    placeholder="Enter SMILES, or a reaction SMILES (A.B>>C)"
                     className="form-input text-lg"
                   />
                 </div>

--- a/flask-app/src/App.tsx
+++ b/flask-app/src/App.tsx
@@ -2419,13 +2419,21 @@ const ChemistryTool: React.FC = () => {
             <div className="card card-padding mb-6">
               <div className="input-row">
                 <div className="flex-1">
-                  <label className="form-label">Starting Molecule (SMILES)</label>
+                  <label className="form-label">
+                    {problemType === 'optimization'
+                      ? 'Starting Molecule (SMILES)'
+                      : 'Starting Molecule (SMILES) or Reaction (reaction SMILES)'}
+                  </label>
                   <input
                     type="text"
                     value={smiles}
                     onChange={(e) => setSmiles(e.target.value)}
                     disabled={isComputing}
-                    placeholder="Enter SMILES or reaction SMILES"
+                    placeholder={
+                      problemType === 'optimization'
+                        ? 'Enter SMILES notation'
+                        : 'Enter SMILES or reaction SMILES'
+                    }
                     className="form-input text-lg"
                   />
                 </div>


### PR DESCRIPTION
Allow users to enter a reaction SMILES (e.g.
"<REACTANT1>.<REACTANT2>>><PRODUCT>") in the retrosynthesis input. Instead of searching routes with AiZynthFinder, the reaction is rendered directly as a one-step partial graph: the largest product becomes the root target node and each reactant becomes a level-1 child, as if the user had run a single retro step.

- New charge_backend/retrosynthesis/reaction_smiles.py builds the graph, reusing is_purchasable, smiles_to_html, and the shared mapped-reaction helper. The root reaction is left with templatesSearched=False so child nodes can still be expanded later via templates/AI.
- Expose parse_reaction_smiles in rdkit_mol_differ.py (agents ignored).
- Route ">>" input to the new path in backend_manager; plain SMILES still runs AiZynthFinder unchanged.
- Frontend: update the input placeholder and derive the experiment name from the product when a reaction SMILES is entered.
- Add tests covering single/multi-product, agent form, and invalid input.